### PR TITLE
Add setup-bazel GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - uses: bazel-contrib/setup-bazel@0.8.2
+      with:
+        bazelisk-cache: true
+        disk-cache: ${{ github.workflow }}
+        repository-cache: true
     - name: Build
       run: ./script/build.sh
     - name: Stage compiled artifacts


### PR DESCRIPTION
This needs to be able to override the cache key to include either the build or arch name.. right now it does:

```
  Failed to save: Unable to reserve cache with key setup-bazel-1-darwin-repository-a3dcd8c595bfb7baa9d2d125eec45a33f14cb89783bb649089891f610a2ac99d, another job may be creating this cache. More details: Cache already exists. Scope: refs/pull/36/merge, Key: setup-bazel-1-darwin-repository-a3dcd8c595bfb7baa9d2d125eec45a33f14cb89783bb649089891f610a2ac99d, Version: f00eabe8580db70cf4bbf166ae9a5d355cd1efb769e0b84744f737422b88169b
```