### PR TITLE
Add Ubuntu 24.04, refactor how runnable exes are collected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -19,19 +19,20 @@ jobs:
           - runner: macos-13
           - runner: macos-14
           - runner: ubuntu-22.04
+          - runner: ubuntu-24.04
     runs-on: ${{ matrix.runner }}
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: ./script/build.sh
-    - name: Stage compiled artifacts
-      run: ./script/stage.sh
-    - name: Archive built artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: binaries-${{ matrix.runner }}
-        path: artifacts
+      - uses: actions/checkout@v4
+      - name: Build
+        run: ./script/build.sh
+      - name: Stage compiled artifacts
+        run: ./script/stage.sh
+      - name: Archive built artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.runner }}
+          path: artifacts
 
   test:
     needs: build
@@ -44,11 +45,11 @@ jobs:
           - runner: ubuntu-22.04
     runs-on: ${{ matrix.runner }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Download artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: binaries-${{ matrix.runner }}
-        path: artifacts
-    - name: Test
-      run: ./script/test.sh
+      - uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-${{ matrix.runner }}
+          path: artifacts
+      - name: Test
+        run: ./script/test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           - runner: macos-13
           - runner: macos-14
           - runner: ubuntu-22.04
+          - runner: ubuntu-24.04
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4

--- a/script/build.sh
+++ b/script/build.sh
@@ -5,17 +5,18 @@ set -euo pipefail
 # shellcheck source=common.sh
 source ./script/common.sh
 
+if [[ "${PLATFORM}" == "linux" ]]; then
+    # A Linux CI runner (e.g. GHA) already has other common dev tools installed, but in
+    # case this looks like some other Ubuntu host, then run some additional required apt installs.
+    if [ -z "${CI:-}" ]; then
+        install_apt_packages
+    fi
+fi
+
+# TODO: deps.sh is down here because it needs curl. We could move the curl installation out of install_apt_packages
+#       and rename it to be just the stuff we need for build-essentials, etc.
 # shellcheck source=deps.sh
 source ./script/deps.sh
-
-if [[ "${PLATFORM}" == "linux" ]]; then
-    # Note, on Linux we may need to set a couple extra things here to support ruby-build
-    if [ -z "${JAVA_HOME:-}" ]; then
-        # shellcheck disable=SC2155
-        export JAVA_HOME="$(dirname "$(dirname "$(realpath "$(which javac)")")")"
-    fi
-    export LANG="en_US.UTF-8"
-fi
 
 bazel info
 bazel build //...

--- a/script/build.sh
+++ b/script/build.sh
@@ -19,6 +19,7 @@ fi
 
 bazel info
 bazel build //...
+
 # At this point these are only lint-type checks
 bazel test --test_output=errors //...
 

--- a/script/common.sh
+++ b/script/common.sh
@@ -3,7 +3,9 @@
 # Intended to be sourced by other scripts
 
 # A query that will return all targets that produce a binary
-# that we want to consider our artifact for testing
+# that we want to consider our artifact for testing.
+#
+# Note that kt is an exception, because we only test the native_image produced kt binary
 export BINARIES_QUERY="
     kind(.*_binary, //src/... except //src/kt/...)
     +kind(native_image, //src/kt/...)"

--- a/script/common.sh
+++ b/script/common.sh
@@ -18,3 +18,35 @@ if [[ "$(uname -s)" = "Linux" ]]; then
     PLATFORM="linux"
 fi
 export PLATFORM
+
+# TODO: comment for why this is needed
+export LANG="en_US.UTF-8"
+
+function install_apt_packages() {
+    apt-get update
+    if ! command -v curl >/dev/null; then
+        apt-get install -y curl
+    fi
+
+    if ! command -v javac >/dev/null; then
+        apt-get install -y openjdk-17-jdk-headless
+    fi
+
+    # Note, on Linux we may need to set a couple extra things here to support ruby-build
+    if [ -z "${JAVA_HOME:-}" ]; then
+        # shellcheck disable=SC2155
+        export JAVA_HOME="$(dirname "$(dirname "$(realpath "$(which javac)")")")"
+    fi
+
+    # what's a good way to detect if we need basic things like libc6-dev?
+    # ..and could we get away with installing a lot fewer packages than all of build-essential?
+    # ..zlib1g-dev is needed for GraalVM native-image
+    # ..libffi/libyaml is needed for Ruby build
+    apt-get install -y \
+        build-essential \
+        libffi-dev \
+        libncurses6 \
+        libyaml-dev \
+        zlib1g-dev
+}
+export -f install_apt_packages

--- a/script/deps.sh
+++ b/script/deps.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+# debug
+set -x
+
 # shellcheck source=common.sh
 source ./script/common.sh
 
 BAZELISK_VERSION=1.19.0
-SWIFT_VERSION=5.10
+SWIFT_VERSION=5.10.1
 
 function install_bazelisk() {
   if command -v bazelisk >/dev/null; then
@@ -50,6 +53,7 @@ install_apt_packages() {
 function install_swift_for_linux() {
   swift_version="${SWIFT_VERSION}"
   ubuntu_version=$(awk -F= '/DISTRIB_RELEASE/ {print $2}' /etc/lsb-release)
+
   # Because Swift Linux releases put a 'aarch64' in the URL for Arm releases, and nothing at all for x86_64
   arch="$(uname -m)"
   if [[ "${arch}" = "arm64" ]] || [[ "${arch}" = "aarch64" ]]; then

--- a/script/deps.sh
+++ b/script/deps.sh
@@ -3,7 +3,7 @@
 # shellcheck source=common.sh
 source ./script/common.sh
 
-BAZELISK_VERSION=1.19.0
+BAZELISK_VERSION=1.20.0
 SWIFT_VERSION=5.10.1
 
 function install_bazelisk() {

--- a/script/deps.sh
+++ b/script/deps.sh
@@ -22,6 +22,7 @@ function install_bazelisk() {
   cp "${bazelisk_path}/bazelisk" "${bazelisk_path}/bazel"
   chmod +x "${bazelisk_path}"/*
   export PATH="${bazelisk_path}:${PATH}"
+  echo "Installed Bazelisk to ${bazelisk_path} and added to PATH"
 }
 
 install_apt_packages() {

--- a/script/deps.sh
+++ b/script/deps.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# debug
-set -x
-
 # shellcheck source=common.sh
 source ./script/common.sh
 

--- a/script/deps.sh
+++ b/script/deps.sh
@@ -25,27 +25,6 @@ function install_bazelisk() {
   echo "Installed Bazelisk to ${bazelisk_path} and added to PATH"
 }
 
-install_apt_packages() {
-  apt-get update
-  if ! command -v curl >/dev/null; then
-    apt-get install -y curl
-  fi
-
-  if ! command -v javac >/dev/null; then
-    apt-get install -y openjdk-17-jdk-headless
-  fi
-
-  # what's a good way to detect if we need basic things like libc6-dev?
-  # ..and could we get away with installing a lot fewer packages than all of build-essential?
-  # ..zlib1g-dev is needed for GraalVM native-image
-  # ..libffi/libyaml is needed for Ruby build
-  apt-get install -y \
-    build-essential \
-    libffi-dev \
-    libyaml-dev \
-    zlib1g-dev
-}
-
 # Can potentially optimize this based on what rules_swift's CI does for Linux:
 # https://github.com/bazelbuild/rules_swift/blob/master/.bazelci/presubmit.yml#L13-L19
 function install_swift_for_linux() {
@@ -83,12 +62,6 @@ if [[ "${PLATFORM}" = "linux" ]]; then
   if [[ "$(awk -F= '/DISTRIB_ID/ {print $2}' /etc/lsb-release)" != "Ubuntu" ]]; then
     echo "On Linux, only Ubuntu platform is supported for building (for now)" >&2
     exit 1
-  fi
-
-  # A Linux CI runner (e.g. GHA) already has other common dev tools installed, but in
-  # case this looks like some other Ubuntu host, then run some additional required apt installs.
-  if [ -z "${CI:-}" ]; then
-    install_apt_packages
   fi
 
   install_bazelisk

--- a/script/stage.sh
+++ b/script/stage.sh
@@ -9,25 +9,27 @@ rm -rf "${STAGING_DIR}"
 
 # List of langs which should produce static, relocatable binaries
 # which we can stage and test on a different worker
-for lang in c go kt rs swift zig; do
-  mkdir -p "${STAGING_DIR}/${PLATFORM}/${lang}"
+mkdir -p "${STAGING_DIR}"
 
-  # Run this query to just get the runnable executable path
-  #
-  # We squelch progress output and even errors, because other lib type targets
-  # have no executable path which could get returned by `target.files_to_run.executable.path`
-  #
-  # TODO: instead of doing //src/${lang} loop, we should just take the same target list from our original build query in build.sh
-  # also TODO: doing the above could probably allow us to remove the -error/info ui_event_filter because we wouldn't
-  # be including other targets under ...
+# Run this query to just get the runnable executable path
+#
+# We squelch progress output and even errors, because other lib type targets
+# have no executable path which could get returned by `target.files_to_run.executable.path`
+#
+# TODO: instead of doing //src/${lang} loop, we should just take the same target list from our original build query in build.sh
+# also TODO: doing the above could probably allow us to remove the -error/info ui_event_filter because we wouldn't
+# be including other targets under ...
 
-  output_exe_path=$(bazel cquery \
-    --noshow_progress \
-    --ui_event_filters=-info,-error \
-    --output=starlark \
-    --starlark:expr='target.files_to_run.executable.path if target.files_to_run.executable.path.endswith("uptime") else ""' \
-    //src/${lang}/... |
-    xargs)
+output_exes=()
 
-  cp -v "${output_exe_path}" "${STAGING_DIR}/${PLATFORM}/${lang}"
+bazel cquery --output=starlark --starlark:file=script/util/runnable_exes.star //src/... |
+  awk NF |
+  while IFS= read -r line; do
+    output_exes+=("$line")
+  done
+
+for exe in "${output_exes[@]}"; do
+  intermediate_path=$(dirname "$exe")
+  mkdir -p "$STAGING_DIR/$intermediate_path"
+  cp "$exe" "$STAGING_DIR/$intermediate_path/"
 done

--- a/script/stage.sh
+++ b/script/stage.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 # shellcheck source=common.sh
 source ./script/common.sh
 
+# Because we still use bazel in this staging script, we still invoke deps.sh because it will
+# ensure that the PATH is updated to include the swift distribution's bin dirs.
+# shellcheck source=deps.sh
+source ./script/deps.sh
+
 rm -rf "${STAGING_DIR}" && mkdir -p "${STAGING_DIR}"
 
 # We assemble the output of a Bazel query into an array that holds all runnable executables.

--- a/script/test.sh
+++ b/script/test.sh
@@ -9,4 +9,5 @@ source ./script/common.sh
 # TODO: re-check this assumption, this seems like would be very wrong
 chmod -R a+x "${STAGING_DIR}"
 
-find "${STAGING_DIR}" -type f -name uptime -print -exec {} \;
+# We don't use `find -exec` here because we want the script to error immediately if any of them fail
+for bin in $(find "${STAGING_DIR}" -type f -name uptime); do $bin; done

--- a/script/test.sh
+++ b/script/test.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 # shellcheck source=common.sh
 source ./script/common.sh
 
+# TODO: deps.sh is only here effectively for installing the swift runtime (until we can implement static linking on Linux)
+#       but really, we should export only the swift runtime install function out of common.sh or something, and call it here.
+# shellcheck source=deps.sh
+source ./script/deps.sh
+
 # For whatever reason, the archive tar process doesn't preserve executability on the mode
 # TODO: re-check this assumption, this seems like would be very wrong
 chmod -R a+x "${STAGING_DIR}"

--- a/script/test.sh
+++ b/script/test.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 source ./script/common.sh
 
 # For whatever reason, the archive tar process doesn't preserve executability on the mode
+# TODO: re-check this assumption, this seems like would be very wrong
 chmod -R a+x "${STAGING_DIR}"
 
 find "${STAGING_DIR}" -type f -name uptime -print -exec {} \;

--- a/script/util/runnable_exes.star
+++ b/script/util/runnable_exes.star
@@ -1,0 +1,10 @@
+def format(target):
+    # This currently results in a lot of:
+    # Error: 'NoneType' value has no field or method 'path'
+    #
+    # TODO: improve this Starlark so that we can filter out the non-applicable targets for this
+    #       query before we try and access any executable-related attributes
+    if target.files_to_run.executable.path.endswith("uptime") and "py" not in str(target.label):
+        return target.files_to_run.executable.path
+    else:
+        return ""

--- a/src/swift/BUILD
+++ b/src/swift/BUILD
@@ -31,3 +31,7 @@ swift_binary(
         "//conditions:default": [],
     }),
 )
+
+# TODO: for linux we need to provide different flags to ensure the included runtime
+#       libs are statically-linked:
+#       https://stackoverflow.com/a/78075257


### PR DESCRIPTION
Also add the swift runtime to Ubuntu tests, because static linking on Linux via rules_swift isn't yet so straightforward.