### PR TITLE
Cache repository deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Save repo cache
         uses: actions/cache/save@v4
         id: cache
+        if: steps.restore-cache.outputs.cache-hit != 'true'
         with:
           path: ${{ steps.get-cache-path.outputs.bazel_repo_cache_path }}
           key: ${{ matrix.runner }}-${{ hashFiles('MODULE.bazel') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         id: restore-cache
         with:
           path: ${{ steps.get-cache-path.outputs.bazel_repo_cache_path }}
-          key: ${{ runner.os }}-${{ hashFiles('MODULE.bazel') }}
+          key: ${{ runner.name }}-${{ hashFiles('MODULE.bazel') }}
       - name: Build
         run: ./script/build.sh
       - name: Stage compiled artifacts
@@ -47,7 +47,7 @@ jobs:
         id: cache
         with:
           path: ${{ steps.get-cache-path.outputs.bazel_repo_cache_path }}
-          key: ${{ runner.os }}-${{ hashFiles('MODULE.bazel') }}
+          key: ${{ runner.name }}-${{ hashFiles('MODULE.bazel') }}
 
   test:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         id: restore-cache
         with:
           path: ${{ steps.get-cache-path.outputs.bazel_repo_cache_path }}
-          key: ${{ matrix.runner }}-${{ hashFiles('MODULE.bazel') }}
+          key: ${{ matrix.runner }}
       - name: Build
         run: ./script/build.sh
       - name: Stage compiled artifacts
@@ -50,7 +50,7 @@ jobs:
         if: steps.restore-cache.outputs.cache-hit != 'true'
         with:
           path: ${{ steps.get-cache-path.outputs.bazel_repo_cache_path }}
-          key: ${{ matrix.runner }}-${{ hashFiles('MODULE.bazel') }}
+          key: ${{ matrix.runner }}
 
   test:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Get cache path
+        id: get-cache-path
+        run: |
+          echo "bazel_repo_cache_path=$(bazel info repository_cache)" >>"$GITHUB_OUTPUT"
+      - uses: actions/cache/restore@v4
+        id: restore-cache
+        with:
+          path: ${{ steps.get-cache-path.outputs.bazel_repo_cache_path }}
+          key: ${{ runner.os }}-${{ hashFiles('MODULE.bazel') }}
       - name: Build
         run: ./script/build.sh
       - name: Stage compiled artifacts
@@ -34,6 +43,11 @@ jobs:
         with:
           name: binaries-${{ matrix.runner }}
           path: artifacts
+      - uses: actions/cache/save@v4
+        id: cache
+        with:
+          path: ${{ steps.get-cache-path.outputs.bazel_repo_cache_path }}
+          key: ${{ runner.os }}-${{ hashFiles('MODULE.bazel') }}
 
   test:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
         id: get-cache-path
         run: |
           echo "bazel_repo_cache_path=$(bazel info repository_cache)" >>"$GITHUB_OUTPUT"
-      - uses: actions/cache/restore@v4
+      - name: Restore repo cache
+        uses: actions/cache/restore@v4
         id: restore-cache
         with:
           path: ${{ steps.get-cache-path.outputs.bazel_repo_cache_path }}
@@ -43,7 +44,8 @@ jobs:
         with:
           name: binaries-${{ matrix.runner }}
           path: artifacts
-      - uses: actions/cache/save@v4
+      - name: Save repo cache
+        uses: actions/cache/save@v4
         id: cache
         with:
           path: ${{ steps.get-cache-path.outputs.bazel_repo_cache_path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         id: restore-cache
         with:
           path: ${{ steps.get-cache-path.outputs.bazel_repo_cache_path }}
-          key: ${{ runner.name }}-${{ hashFiles('MODULE.bazel') }}
+          key: ${{ matrix.runner }}-${{ hashFiles('MODULE.bazel') }}
       - name: Build
         run: ./script/build.sh
       - name: Stage compiled artifacts
@@ -47,7 +47,7 @@ jobs:
         id: cache
         with:
           path: ${{ steps.get-cache-path.outputs.bazel_repo_cache_path }}
-          key: ${{ runner.name }}-${{ hashFiles('MODULE.bazel') }}
+          key: ${{ matrix.runner }}-${{ hashFiles('MODULE.bazel') }}
 
   test:
     needs: build


### PR DESCRIPTION
This doesn't really seem any faster. Could it be because we don't yet check in our module lock file, and so it's re-resolving everything anyway?

Separately the cache files seem like they may only live for 7 days anyway, so seems most of the time they will be already expired.