### PR TITLE
Fix Python Darwin timeval ABI

### DIFF
--- a/src/py/uptime.py
+++ b/src/py/uptime.py
@@ -7,6 +7,7 @@ from ctypes import Structure, byref, c_int32, c_long, c_size_t, sizeof, util
 # Load the libc library
 libc = ctypes.CDLL(util.find_library("c"))
 
+
 class timeval(Structure):
     _fields_ = [
         ("tv_sec", c_long),
@@ -16,7 +17,13 @@ class timeval(Structure):
 
 def get_system_uptime_darwin():
     sysctlbyname = libc.sysctlbyname
-    sysctlbyname.argtypes = [ctypes.c_char_p, ctypes.c_void_p, ctypes.POINTER(c_size_t), ctypes.c_void_p, c_size_t]
+    sysctlbyname.argtypes = [
+        ctypes.c_char_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(c_size_t),
+        ctypes.c_void_p,
+        c_size_t,
+    ]
     sysctlbyname.restype = ctypes.c_int
 
     libc.time.argtypes = [ctypes.c_void_p]

--- a/src/py/uptime.py
+++ b/src/py/uptime.py
@@ -14,20 +14,21 @@ class timeval(Structure):
     ]
 
 
-libc.sysctlbyname.argtypes = [ctypes.c_char_p, ctypes.c_void_p, ctypes.POINTER(c_size_t), ctypes.c_void_p, c_size_t]
-libc.sysctlbyname.restype = ctypes.c_int
-libc.time.argtypes = [ctypes.c_void_p]
-libc.time.restype = c_long
-
-
 def get_system_uptime_darwin():
+    sysctlbyname = libc.sysctlbyname
+    sysctlbyname.argtypes = [ctypes.c_char_p, ctypes.c_void_p, ctypes.POINTER(c_size_t), ctypes.c_void_p, c_size_t]
+    sysctlbyname.restype = ctypes.c_int
+
+    libc.time.argtypes = [ctypes.c_void_p]
+    libc.time.restype = c_long
+
     # Create an instance of timeval
     tv = timeval()
     # The size of the timeval structure
     size = c_size_t(sizeof(tv))
 
     # Get the system uptime using sysctlbyname
-    result = libc.sysctlbyname(b"kern.boottime", byref(tv), byref(size), None, 0)
+    result = sysctlbyname(b"kern.boottime", byref(tv), byref(size), None, 0)
 
     if result != 0:
         # If there is an error (non-zero result), raise an exception
@@ -41,11 +42,20 @@ def get_system_uptime_darwin():
     return uptime_seconds
 
 
-system = platform.uname().system
-if system == "Linux":
-    with open("/proc/uptime", "r") as f:
-        uptime_seconds = int(float(f.readline().split()[0]))
-        print(uptime_seconds)
+def main():
+    system = platform.uname().system
+    if system == "Linux":
+        with open("/proc/uptime", "r") as f:
+            uptime_seconds = int(float(f.readline().split()[0]))
+            print(uptime_seconds)
+        return
 
-if system == "Darwin":
-    print(get_system_uptime_darwin())
+    if system == "Darwin":
+        print(get_system_uptime_darwin())
+        return
+
+    raise NotImplementedError(f"unsupported platform: {system}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/py/uptime.py
+++ b/src/py/uptime.py
@@ -1,28 +1,30 @@
 #!/usr/bin/env python
 
-import platform
-
 import ctypes
-from ctypes import util, Structure, c_uint, c_ulonglong, sizeof, byref
+import platform
+from ctypes import Structure, byref, c_int32, c_long, c_size_t, sizeof, util
 
 # Load the libc library
 libc = ctypes.CDLL(util.find_library("c"))
 
-# Define the structure for timeval (used to store the uptime)
-
-
 class timeval(Structure):
     _fields_ = [
-        ("tv_sec", c_ulonglong),  # seconds
-        ("tv_usec", c_ulonglong),
-    ]  # microseconds
+        ("tv_sec", c_long),
+        ("tv_usec", c_int32),
+    ]
+
+
+libc.sysctlbyname.argtypes = [ctypes.c_char_p, ctypes.c_void_p, ctypes.POINTER(c_size_t), ctypes.c_void_p, c_size_t]
+libc.sysctlbyname.restype = ctypes.c_int
+libc.time.argtypes = [ctypes.c_void_p]
+libc.time.restype = c_long
 
 
 def get_system_uptime_darwin():
     # Create an instance of timeval
     tv = timeval()
     # The size of the timeval structure
-    size = c_uint(sizeof(tv))
+    size = c_size_t(sizeof(tv))
 
     # Get the system uptime using sysctlbyname
     result = libc.sysctlbyname(b"kern.boottime", byref(tv), byref(size), None, 0)


### PR DESCRIPTION
## Summary
- match the Python Darwin `timeval` definition to the libc layout used elsewhere in the repo
- use `c_size_t` for the `sysctlbyname` buffer length and declare ctypes signatures explicitly
- keep the Linux code path unchanged

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile src/py/uptime.py`
