### PR TITLE
Set Go importpath explicitly

### DIFF
--- a/src/go/BUILD.bazel
+++ b/src/go/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "uptime_darwin.go",
         "uptime_linux.go",
     ],
-    importpath = "",
+    importpath = "github.com/timsutton/uptime/src/go",
     visibility = ["//visibility:private"],
 )
 


### PR DESCRIPTION
## Summary
- replace the empty `importpath` in `src/go/BUILD.bazel` with the repository's actual Go import path
- keep the target structure unchanged while avoiding a fragile non-standard `rules_go` setup

## Validation
- `bazel build //src/go:uptime`
