### PR TITLE
[codex] Make Bazel remote cache fallback non-blocking

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,7 +18,9 @@ build:macos --features=noop-this-is-because-we-have-no-config-flags-to-set-yet-o
 build:linux --features=swift.static_stdlib
 
 # Remote cache
-# Use my Tailnet's remote cache on Linux, fall back to local if it has errors
+# Use my Tailnet's remote cache on Linux, but keep builds working if the cache
+# endpoint is unavailable.
 build:linux --remote_cache=grpc://bazel-remote.tailff30e.ts.net:9092
 build:linux --remote_local_fallback
+build:linux --incompatible_remote_local_fallback_for_remote_cache
 build:linux --remote_download_outputs=minimal


### PR DESCRIPTION
## Summary
This change makes the Linux Bazel remote cache configuration degrade to local execution when the gRPC cache endpoint is unavailable.

## Root Cause
Bazel 9 exposes `--incompatible_remote_local_fallback_for_remote_cache`, and `--remote_local_fallback` alone does not cover plain `--remote_cache` failures. That meant CI could still fail when the remote cache endpoint was down.

## Changes
- update the `.bazelrc` Linux remote cache comment to match the intended behavior
- add `--incompatible_remote_local_fallback_for_remote_cache` alongside the existing Linux remote cache flags

## Impact
Linux CI should keep building and testing locally instead of failing when the remote cache is unavailable.

## Validation
- `bazel info --config=linux release`
- `bazel help build | rg "incompatible_remote_local_fallback_for_remote_cache|remote_local_fallback"`