### PR TITLE
Update Ruby checksums

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -107,25 +107,20 @@ ruby.toolchain(
 ruby.bundle_fetch(
     name = "bundle",
     gem_checksums = {
-        "addressable-2.8.9": "cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485",
         "ast-2.4.3": "954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383",
-        "bigdecimal-4.0.1": "8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7",
-        "ffi-1.17.3": "0e9f39f7bb3934f77ad6feab49662be77e87eedcdeb2a3f5c0234c2938563d4c",
-        "ffi-1.17.3-arm64-darwin": "0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f",
-        "json-2.19.1": "dd94fdc59e48bff85913829a32350b3148156bc4fd2a95a2568a78b11344082d",
-        "json-schema-6.2.0": "e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666",
+        "ffi-1.17.4": "bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf",
+        "ffi-1.17.4-arm64-darwin": "19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b",
+        "json-2.19.3": "289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646",
         "language_server-protocol-3.17.0.5": "fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc",
         "lint_roller-1.1.0": "2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87",
-        "mcp-0.8.0": "ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb",
         "parallel-1.27.0": "4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130",
-        "parser-3.3.10.2": "6f60c84aa4bdcedb6d1a2434b738fe8a8136807b6adc8f7f53b97da9bc4e9357",
+        "parser-3.3.11.1": "d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54",
         "prism-1.9.0": "7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85",
-        "public_suffix-7.0.5": "1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623",
         "racc-1.8.1": "4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f",
         "rainbow-3.1.1": "039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a",
         "regexp_parser-2.11.3": "ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4",
-        "rubocop-1.85.1": "3dbcf9e961baa4c376eeeb2a03913dca5e3987033b04d38fa538aa1e7406cc77",
-        "rubocop-ast-1.49.0": "49c3676d3123a0923d333e20c6c2dbaaae2d2287b475273fddee0c61da9f71fd",
+        "rubocop-1.86.1": "44415f3f01d01a21e01132248d2fd0867572475b566ca188a0a42133a08d4531",
+        "rubocop-ast-1.49.1": "4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035",
         "ruby-progressbar-1.13.0": "80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33",
         "unicode-display_width-3.2.0": "0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42",
         "unicode-emoji-4.2.0": "519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f",
@@ -219,8 +214,8 @@ http_file(
 http_file(
     name = "clang_format_linux",
     executable = True,
-    sha256 = "8a933fe6eaac72f115d98ab56dc6e1b22af4dc53d32119108ebfd0b8e71ab6e1",
-    url = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-46b8640/clang-format-19_linux-amd64",
+    sha256 = "e900c1e520b6c9b9c99e43c0f45ccd12927838741cfc60c077a33dec69bb60cc",
+    url = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-796e77c/clang-format-20_linux-amd64",
 )
 
 http_jar(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -214,8 +214,8 @@ http_file(
 http_file(
     name = "clang_format_linux",
     executable = True,
-    sha256 = "e900c1e520b6c9b9c99e43c0f45ccd12927838741cfc60c077a33dec69bb60cc",
-    url = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-796e77c/clang-format-20_linux-amd64",
+    sha256 = "8a933fe6eaac72f115d98ab56dc6e1b22af4dc53d32119108ebfd0b8e71ab6e1",
+    url = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-46b8640/clang-format-19_linux-amd64",
 )
 
 http_jar(


### PR DESCRIPTION
## Summary
- refresh the `ruby.bundle_fetch` checksum map in `MODULE.bazel` to match the gems locked in `src/rb/Gemfile.lock`
- leave clang-format unchanged so Linux and macOS can be bumped together later

## Validation
- ran `bazel build //src/rb:rubocop //tools/format:clang_format`