### PR TITLE
Use latest clang-format static binaries

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -200,22 +200,19 @@ http_archive(
 # Note that we intentionally don't fetch clang-format from the llvm_toolchains repo, because the llvm archives
 # are very time-consuming to download and extract.
 
-# On Mac, mirror an arm64 copy from homebrew, which happens to build it portably
-# - Note, this repo has Mac binaries but (1) the architectures can be not matching the filename, and (2) they depend on dylibs
-#   not present on every Mac system.
+# Pull static clang-format binaries for both platforms from the latest tagged release.
 http_file(
     name = "clang_format_mac",
     executable = True,
-    sha256 = "ea8f6231e4f75362fa6d61135cb89f541c7821ac0edc7525c77ea91ba49b12bd",
-    url = "https://github.com/timsutton/clang-format-binaries/releases/download/19.1.6/clang-format-darwin-arm64",
+    sha256 = "fe6b8450a8cf83de3f517e3b9a9b1bb925613e5fb59145d6d24ccca5fe17d442",
+    url = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-796e77c/clang-format-20_macos-arm-arm64",
 )
 
-# On Linux we pull a static binary
 http_file(
     name = "clang_format_linux",
     executable = True,
-    sha256 = "8d0b2012a70032666cbc4503ff10b4a37aad556c24f5ab6a09f67e17c5b9c9c1",
-    url = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-796e77c/clang-format-19_linux-amd64",
+    sha256 = "e900c1e520b6c9b9c99e43c0f45ccd12927838741cfc60c077a33dec69bb60cc",
+    url = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-796e77c/clang-format-20_linux-amd64",
 )
 
 http_jar(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -214,8 +214,8 @@ http_file(
 http_file(
     name = "clang_format_linux",
     executable = True,
-    sha256 = "8a933fe6eaac72f115d98ab56dc6e1b22af4dc53d32119108ebfd0b8e71ab6e1",
-    url = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-46b8640/clang-format-19_linux-amd64",
+    sha256 = "8d0b2012a70032666cbc4503ff10b4a37aad556c24f5ab6a09f67e17c5b9c9c1",
+    url = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-796e77c/clang-format-19_linux-amd64",
 )
 
 http_jar(

--- a/renovate.json
+++ b/renovate.json
@@ -61,6 +61,42 @@
                 "/(^|/)MODULE\\.bazel$/"
             ],
             "matchStrings": [
+                "url\\s*=\\s*\"https://github\\.com/timsutton/clang-format-binaries/releases/download/(?<currentValue>[^\"]+)/clang-format-darwin-arm64\""
+            ],
+            "datasourceTemplate": "github-releases",
+            "depNameTemplate": "timsutton/clang-format-binaries",
+            "versioningTemplate": "semver"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/(^|/)MODULE\\.bazel$/"
+            ],
+            "matchStrings": [
+                "url\\s*=\\s*\"https://github\\.com/muttleyxd/clang-tools-static-binaries/releases/download/(?<currentValue>[^\"]+)/clang-format-19_linux-amd64\""
+            ],
+            "datasourceTemplate": "github-releases",
+            "depNameTemplate": "muttleyxd/clang-tools-static-binaries",
+            "versioningTemplate": "loose"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/(^|/)MODULE\\.bazel$/"
+            ],
+            "matchStrings": [
+                "url\\s*=\\s*\"https://github\\.com/nicklockwood/SwiftFormat/releases/download/(?<currentValue>[^\"]+)/swiftformat(?:_linux)?\\.zip\""
+            ],
+            "datasourceTemplate": "github-releases",
+            "depNameTemplate": "nicklockwood/SwiftFormat",
+            "versioningTemplate": "semver"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/(^|/)MODULE\\.bazel$/"
+            ],
+            "matchStrings": [
                 "zig\\.toolchain\\(zig_version\\s*=\\s*\"(?<currentValue>[^\"]+)\"\\)"
             ],
             "datasourceTemplate": "github-releases",

--- a/renovate.json
+++ b/renovate.json
@@ -61,11 +61,11 @@
                 "/(^|/)MODULE\\.bazel$/"
             ],
             "matchStrings": [
-                "url\\s*=\\s*\"https://github\\.com/timsutton/clang-format-binaries/releases/download/(?<currentValue>[^\"]+)/clang-format-darwin-arm64\""
+                "url\\s*=\\s*\"https://github\\.com/muttleyxd/clang-tools-static-binaries/releases/download/(?<currentValue>[^\"]+)/clang-format-20_macos-arm-arm64\""
             ],
             "datasourceTemplate": "github-releases",
-            "depNameTemplate": "timsutton/clang-format-binaries",
-            "versioningTemplate": "semver"
+            "depNameTemplate": "muttleyxd/clang-tools-static-binaries",
+            "versioningTemplate": "loose"
         },
         {
             "customType": "regex",
@@ -73,7 +73,7 @@
                 "/(^|/)MODULE\\.bazel$/"
             ],
             "matchStrings": [
-                "url\\s*=\\s*\"https://github\\.com/muttleyxd/clang-tools-static-binaries/releases/download/(?<currentValue>[^\"]+)/clang-format-19_linux-amd64\""
+                "url\\s*=\\s*\"https://github\\.com/muttleyxd/clang-tools-static-binaries/releases/download/(?<currentValue>[^\"]+)/clang-format-20_linux-amd64\""
             ],
             "datasourceTemplate": "github-releases",
             "depNameTemplate": "muttleyxd/clang-tools-static-binaries",


### PR DESCRIPTION
## Summary
- switch macOS and Linux clang-format to the latest static binaries from `muttleyxd/clang-tools-static-binaries`
- update macOS from the stale mirrored `19.1.6` binary to `clang-format 20.1.0`
- update Linux from `clang-format 19` to `clang-format 20`
- keep Renovate tracking the clang-format and SwiftFormat URLs in `MODULE.bazel`

## Verification
- downloaded the new macOS asset, confirmed its SHA-256, verified it is arm64, and ran `--version`
- checked the macOS binary linkage with `otool -L`; it only links `libSystem`
- downloaded the new Linux asset and confirmed its SHA-256
- validated `renovate.json` with `jq`
- attempted a Bazel query earlier, but Bazel stalled during module resolution, so CI remains the main verification path