### PR TITLE
Use OSHI for Kotlin GraalVM uptime

### DIFF
--- a/src/kt/BUILD
+++ b/src/kt/BUILD
@@ -26,9 +26,9 @@ kt_jvm_binary(
         ":macos": "MainDarwinKt",
     }),
     visibility = ["//visibility:private"],
-    # deps = [
-    #     "@maven_jvm_external//:com_github_oshi",
-    # ],
+    deps = [
+        "@maven//:com_github_oshi_oshi_core",
+    ],
 )
 
 # java_library(
@@ -41,10 +41,14 @@ kt_jvm_binary(
 native_image(
     name = "uptime",
     executable_name = "%target%",
+    include_resources = "com/sun/jna/.*",
     main_class = select({
         ":linux": "MainLinuxKt",
         ":macos": "MainDarwinKt",
     }),
     native_image_tool = "@graalvm//:native-image",
     deps = [":uptime_jar"],
+    jni_configuration = "jna-jni-config.json",
+    proxy_configuration = "jna-proxy-config.json",
+    reflection_configuration = "jna-reflection-config.json",
 )

--- a/src/kt/BUILD
+++ b/src/kt/BUILD
@@ -42,13 +42,13 @@ native_image(
     name = "uptime",
     executable_name = "%target%",
     include_resources = "com/sun/jna/.*",
+    jni_configuration = "jna-jni-config.json",
     main_class = select({
         ":linux": "MainLinuxKt",
         ":macos": "MainDarwinKt",
     }),
     native_image_tool = "@graalvm//:native-image",
-    deps = [":uptime_jar"],
-    jni_configuration = "jna-jni-config.json",
     proxy_configuration = "jna-proxy-config.json",
     reflection_configuration = "jna-reflection-config.json",
+    deps = [":uptime_jar"],
 )

--- a/src/kt/BUILD
+++ b/src/kt/BUILD
@@ -41,6 +41,7 @@ kt_jvm_binary(
 native_image(
     name = "uptime",
     executable_name = "%target%",
+    extra_args = ["-H:+AddAllCharsets"],
     include_resources = "com/sun/jna/.*",
     jni_configuration = "jna-jni-config.json",
     main_class = select({

--- a/src/kt/BUILD
+++ b/src/kt/BUILD
@@ -31,13 +31,6 @@ kt_jvm_binary(
     ],
 )
 
-# java_library(
-#     name = "my_lib",
-#     exports = [
-#         "@maven_jvm_external//:com_github_oshi",
-#     ],
-# )
-
 native_image(
     name = "uptime",
     executable_name = "%target%",

--- a/src/kt/MainDarwin.kt
+++ b/src/kt/MainDarwin.kt
@@ -1,19 +1,9 @@
-import java.io.BufferedReader
-import java.io.InputStreamReader
+import oshi.SystemInfo
 
 fun main() {
   try {
-    // TODO: don't use shell out, actually use the sysctl C API
-    // or try out OSHI: https://github.com/oshi/oshi
-    val process = ProcessBuilder("sysctl", "kern.boottime").redirectErrorStream(true).start()
-
-    val input = BufferedReader(InputStreamReader(process.inputStream))
-    val output = input.readText()
-    input.close()
-
-    val bootTime = output.substringAfter("sec = ").substringBefore(",")
-    var currentTime = System.currentTimeMillis() / 1000
-    println("%s".format(currentTime - bootTime.toLong()))
+    val uptimeSeconds = SystemInfo().operatingSystem.systemUptime
+    println(uptimeSeconds)
   } catch (e: Exception) {
     e.printStackTrace()
   }

--- a/src/kt/MainLinux.kt
+++ b/src/kt/MainLinux.kt
@@ -1,14 +1,8 @@
-import java.io.File
+import oshi.SystemInfo
 
 fun main() {
   try {
-    val lines = File("/proc/stat").readLines()
-    val btimeLine = lines.first { it.startsWith("btime") }
-    val bootTimeSeconds = btimeLine.split(" ")[1].toLong()
-
-    val currentTimeSeconds = System.currentTimeMillis() / 1000
-    val uptimeSeconds = currentTimeSeconds - bootTimeSeconds
-
+    val uptimeSeconds = SystemInfo().operatingSystem.systemUptime
     println("$uptimeSeconds")
   } catch (e: Exception) {
     e.printStackTrace()

--- a/src/kt/README.md
+++ b/src/kt/README.md
@@ -1,0 +1,141 @@
+# Kotlin GraalVM Notes
+
+This target uses OSHI inside a GraalVM native image, which means it also pulls in JNA and needs explicit native-image metadata.
+
+## Why these config files exist
+
+The native image currently depends on these metadata files:
+
+- `jna-reflection-config.json`
+- `jna-jni-config.json`
+- `jna-proxy-config.json`
+
+They exist because OSHI and JNA do work dynamically at runtime:
+
+- reflection on classes, fields, and constructors
+- JNI access
+- `Proxy` generation for JNA `Library` interfaces
+- loading bundled native resources from the JNA jars
+
+Without that metadata, the native image builds but fails at runtime with errors like:
+
+- `MissingReflectionRegistrationError`
+- missing dynamic proxy metadata
+- missing JNA resources
+- missing constructor/field reflection metadata
+- missing charset support
+
+## How these files were derived
+
+These files were not written from scratch blindly. They came from a combination of:
+
+1. GraalVM's official reachability metadata
+2. Iteration from actual native-image runtime failures
+3. Bytecode inspection of OSHI/JNA classes
+
+### 1. Official reachability metadata
+
+The initial seed came from the GraalVM reachability metadata repository:
+
+- <https://github.com/oracle/graalvm-reachability-metadata>
+
+In particular, the JNA metadata there was used as a starting point. That repository uses the newer combined `reachability-metadata.json` format, while this Bazel setup passes separate config files to `native-image`, so the JNA metadata had to be translated into split files like:
+
+- `reflect-config.json`
+- `jni-config.json`
+- `proxy-config.json`
+
+### 2. Iteration from runtime errors
+
+After wiring OSHI into the Kotlin target, the native image was built and executed repeatedly. Each failure identified the next missing piece of metadata. Examples that came up while getting this target working:
+
+- JNA native resources were not included
+- reflection metadata was missing for JNA structure classes and helper classes
+- dynamic proxy metadata was missing for JNA interfaces on macOS and Linux
+- additional charsets were required because OSHI references `Windows-1252`
+
+The CI failures were also useful here. For example, Linux runners later reported a missing proxy registration for `com.sun.jna.platform.linux.Udev`, which was then added to `jna-proxy-config.json`.
+
+### 3. Inspecting classes directly
+
+For classes named in the failures, `javap` was used against the resolved `oshi`, `jna`, and `jna-platform` jars to confirm things like:
+
+- whether a type was a JNA `Library` interface and therefore needed proxy metadata
+- whether a class had a public no-arg constructor
+- which nested helper classes existed
+
+That made it possible to add targeted metadata instead of broad, unbounded config.
+
+## How a person would do this by hand
+
+If doing this manually, the usual workflow is:
+
+1. Build the native image
+2. Run it
+3. Read the failure carefully
+4. Add only the metadata the failure calls out
+5. Rebuild and repeat
+
+Typical categories:
+
+- reflection config: classes, constructors, fields, methods
+- JNI config: classes/methods/fields looked up from native code
+- proxy config: exact interface lists for `Proxy` generation
+- resource config: native resources or other files that must be embedded
+
+This process is iterative. Native-image errors are often explicit enough to drive the next fix directly.
+
+## Tooling that helps generate this metadata
+
+The main GraalVM tool for this is the Native Image tracing agent.
+
+You run the program on a regular JVM with the agent enabled:
+
+```bash
+java -agentlib:native-image-agent=config-output-dir=./native-image-config ...
+```
+
+It records dynamic behavior that actually occurs during the run and emits files such as:
+
+- `reflect-config.json`
+- `jni-config.json`
+- `proxy-config.json`
+- `resource-config.json`
+
+You can also merge multiple runs with:
+
+```bash
+java -agentlib:native-image-agent=config-merge-dir=./native-image-config ...
+```
+
+This is the best first step for most applications.
+
+Relevant docs:
+
+- <https://www.graalvm.org/latest/reference-manual/native-image/metadata/AutomaticMetadataCollection/>
+- <https://www.graalvm.org/jdk24/reference-manual/native-image/guides/configure-with-tracing-agent/>
+- <https://www.graalvm.org/latest/reference-manual/native-image/metadata/>
+
+## Important limitation of the tracing agent
+
+The tracing agent only records code paths you actually execute.
+
+That means:
+
+- it is very useful
+- it is not automatically complete
+
+If you only exercise one OS path or one runtime branch, the generated metadata may still be missing entries for other platforms or code paths. That is why this target still required follow-up fixes after the first pass.
+
+## Practical recommendation for this target
+
+If this target changes again, the most practical workflow is:
+
+1. Start from the existing metadata files in this directory
+2. Run the JVM version with the tracing agent enabled
+3. Exercise the target on both macOS and Linux if possible
+4. Merge the generated output
+5. Rebuild the native image
+6. Use any remaining runtime errors to make targeted fixes
+
+That should be much faster and safer than rebuilding all of this context from scratch.

--- a/src/kt/jna-jni-config.json
+++ b/src/kt/jna-jni-config.json
@@ -1,0 +1,687 @@
+[
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.Callback"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.CallbackReference",
+    "methods": [
+      {
+        "name": "getCallback",
+        "parameterTypes": [
+          "java.lang.Class",
+          "com.sun.jna.Pointer",
+          "boolean"
+        ]
+      },
+      {
+        "name": "getFunctionPointer",
+        "parameterTypes": [
+          "com.sun.jna.Callback",
+          "boolean"
+        ]
+      },
+      {
+        "name": "getNativeString",
+        "parameterTypes": [
+          "java.lang.Object",
+          "boolean"
+        ]
+      },
+      {
+        "name": "initializeThread",
+        "parameterTypes": [
+          "com.sun.jna.Callback",
+          "com.sun.jna.CallbackReference$AttachOptions"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.CallbackReference$AttachOptions"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.FromNativeConverter",
+    "methods": [
+      {
+        "name": "nativeType",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.IntegerType",
+    "fields": [
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.JNIEnv"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.Native",
+    "methods": [
+      {
+        "name": "dispose",
+        "parameterTypes": []
+      },
+      {
+        "name": "fromNative",
+        "parameterTypes": [
+          "com.sun.jna.FromNativeConverter",
+          "java.lang.Object",
+          "java.lang.reflect.Method"
+        ]
+      },
+      {
+        "name": "fromNative",
+        "parameterTypes": [
+          "java.lang.Class",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "fromNative",
+        "parameterTypes": [
+          "java.lang.reflect.Method",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "nativeType",
+        "parameterTypes": [
+          "java.lang.Class"
+        ]
+      },
+      {
+        "name": "toNative",
+        "parameterTypes": [
+          "com.sun.jna.ToNativeConverter",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.Native$ffi_callback",
+    "methods": [
+      {
+        "name": "invoke",
+        "parameterTypes": [
+          "long",
+          "long",
+          "long"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.NativeMapped",
+    "methods": [
+      {
+        "name": "toNative",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.Pointer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "long"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "peer"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.PointerType",
+    "fields": [
+      {
+        "name": "pointer"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.Structure",
+    "methods": [
+      {
+        "name": "autoRead",
+        "parameterTypes": []
+      },
+      {
+        "name": "autoWrite",
+        "parameterTypes": []
+      },
+      {
+        "name": "getTypeInfo",
+        "parameterTypes": []
+      },
+      {
+        "name": "newInstance",
+        "parameterTypes": [
+          "java.lang.Class",
+          "long"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "memory"
+      },
+      {
+        "name": "typeInfo"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.Structure$ByValue"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.Structure$FFIType$FFITypes",
+    "fields": [
+      {
+        "name": "ffi_type_double"
+      },
+      {
+        "name": "ffi_type_float"
+      },
+      {
+        "name": "ffi_type_longdouble"
+      },
+      {
+        "name": "ffi_type_pointer"
+      },
+      {
+        "name": "ffi_type_sint16"
+      },
+      {
+        "name": "ffi_type_sint32"
+      },
+      {
+        "name": "ffi_type_sint64"
+      },
+      {
+        "name": "ffi_type_sint8"
+      },
+      {
+        "name": "ffi_type_uint16"
+      },
+      {
+        "name": "ffi_type_uint32"
+      },
+      {
+        "name": "ffi_type_uint64"
+      },
+      {
+        "name": "ffi_type_uint8"
+      },
+      {
+        "name": "ffi_type_void"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.WString",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Boolean",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "boolean"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Byte",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "byte"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Character",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "char"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Class",
+    "methods": [
+      {
+        "name": "getComponentType",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Double",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "double"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Float",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "float"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Integer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Long",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "long"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Object",
+    "methods": [
+      {
+        "name": "toString",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Short",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "short"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.String",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "byte[]"
+        ]
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "byte[]",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "getBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getBytes",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "toCharArray",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.System",
+    "methods": [
+      {
+        "name": "getProperty",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Void",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.reflect.Method",
+    "methods": [
+      {
+        "name": "getParameterTypes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getReturnType",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.Buffer",
+    "methods": [
+      {
+        "name": "position",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.ByteBuffer",
+    "methods": [
+      {
+        "name": "array",
+        "parameterTypes": []
+      },
+      {
+        "name": "arrayOffset",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.CharBuffer",
+    "methods": [
+      {
+        "name": "array",
+        "parameterTypes": []
+      },
+      {
+        "name": "arrayOffset",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.DoubleBuffer",
+    "methods": [
+      {
+        "name": "array",
+        "parameterTypes": []
+      },
+      {
+        "name": "arrayOffset",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.FloatBuffer",
+    "methods": [
+      {
+        "name": "array",
+        "parameterTypes": []
+      },
+      {
+        "name": "arrayOffset",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.IntBuffer",
+    "methods": [
+      {
+        "name": "array",
+        "parameterTypes": []
+      },
+      {
+        "name": "arrayOffset",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.LongBuffer",
+    "methods": [
+      {
+        "name": "array",
+        "parameterTypes": []
+      },
+      {
+        "name": "arrayOffset",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.ShortBuffer",
+    "methods": [
+      {
+        "name": "array",
+        "parameterTypes": []
+      },
+      {
+        "name": "arrayOffset",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/src/kt/jna-proxy-config.json
+++ b/src/kt/jna-proxy-config.json
@@ -48,5 +48,10 @@
     "interfaces": [
       "com.sun.jna.platform.linux.LibC"
     ]
+  },
+  {
+    "interfaces": [
+      "com.sun.jna.platform.linux.Udev"
+    ]
   }
 ]

--- a/src/kt/jna-proxy-config.json
+++ b/src/kt/jna-proxy-config.json
@@ -1,0 +1,52 @@
+[
+  {
+    "interfaces": [
+      "oshi.jna.platform.mac.SystemB"
+    ]
+  },
+  {
+    "interfaces": [
+      "com.sun.jna.platform.mac.SystemB"
+    ]
+  },
+  {
+    "interfaces": [
+      "oshi.jna.platform.mac.IOKit"
+    ]
+  },
+  {
+    "interfaces": [
+      "com.sun.jna.platform.mac.IOKit"
+    ]
+  },
+  {
+    "interfaces": [
+      "oshi.jna.platform.mac.SystemConfiguration"
+    ]
+  },
+  {
+    "interfaces": [
+      "oshi.jna.platform.mac.CoreGraphics"
+    ]
+  },
+  {
+    "interfaces": [
+      "oshi.jna.platform.unix.CLibrary"
+    ]
+  },
+  {
+    "interfaces": [
+      "com.sun.jna.platform.unix.LibCAPI"
+    ]
+  },
+  {
+    "interfaces": [
+      "oshi.jna.platform.linux.LinuxLibc"
+    ]
+  },
+  {
+    "interfaces": [
+      "com.sun.jna.platform.linux.LibC"
+    ]
+  }
+]

--- a/src/kt/jna-reflection-config.json
+++ b/src/kt/jna-reflection-config.json
@@ -1,0 +1,939 @@
+[
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.Callback"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.CallbackReference"
+    },
+    "name": "com.sun.jna.CallbackProxy",
+    "methods": [
+      {
+        "name": "callback",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.CallbackReference",
+    "methods": [
+      {
+        "name": "getCallback",
+        "parameterTypes": [
+          "java.lang.Class",
+          "com.sun.jna.Pointer",
+          "boolean"
+        ]
+      },
+      {
+        "name": "getFunctionPointer",
+        "parameterTypes": [
+          "com.sun.jna.Callback",
+          "boolean"
+        ]
+      },
+      {
+        "name": "getNativeString",
+        "parameterTypes": [
+          "java.lang.Object",
+          "boolean"
+        ]
+      },
+      {
+        "name": "initializeThread",
+        "parameterTypes": [
+          "com.sun.jna.Callback",
+          "com.sun.jna.CallbackReference$AttachOptions"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.CallbackReference$AttachOptions"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.FromNativeConverter",
+    "methods": [
+      {
+        "name": "nativeType",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.IntegerType",
+    "fields": [
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.JNIEnv"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.Native",
+    "methods": [
+      {
+        "name": "dispose",
+        "parameterTypes": []
+      },
+      {
+        "name": "fromNative",
+        "parameterTypes": [
+          "com.sun.jna.FromNativeConverter",
+          "java.lang.Object",
+          "java.lang.reflect.Method"
+        ]
+      },
+      {
+        "name": "fromNative",
+        "parameterTypes": [
+          "java.lang.Class",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "fromNative",
+        "parameterTypes": [
+          "java.lang.reflect.Method",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "nativeType",
+        "parameterTypes": [
+          "java.lang.Class"
+        ]
+      },
+      {
+        "name": "toNative",
+        "parameterTypes": [
+          "com.sun.jna.ToNativeConverter",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.Native$ffi_callback",
+    "methods": [
+      {
+        "name": "invoke",
+        "parameterTypes": [
+          "long",
+          "long",
+          "long"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.NativeMapped",
+    "methods": [
+      {
+        "name": "toNative",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.Pointer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "long"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "peer"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.PointerType",
+    "fields": [
+      {
+        "name": "pointer"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.Structure",
+    "methods": [
+      {
+        "name": "autoRead",
+        "parameterTypes": []
+      },
+      {
+        "name": "autoWrite",
+        "parameterTypes": []
+      },
+      {
+        "name": "getTypeInfo",
+        "parameterTypes": []
+      },
+      {
+        "name": "newInstance",
+        "parameterTypes": [
+          "java.lang.Class",
+          "long"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "memory"
+      },
+      {
+        "name": "typeInfo"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.Structure$ByValue"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.Structure$FFIType$FFITypes",
+    "fields": [
+      {
+        "name": "ffi_type_double"
+      },
+      {
+        "name": "ffi_type_float"
+      },
+      {
+        "name": "ffi_type_longdouble"
+      },
+      {
+        "name": "ffi_type_pointer"
+      },
+      {
+        "name": "ffi_type_sint16"
+      },
+      {
+        "name": "ffi_type_sint32"
+      },
+      {
+        "name": "ffi_type_sint64"
+      },
+      {
+        "name": "ffi_type_sint8"
+      },
+      {
+        "name": "ffi_type_uint16"
+      },
+      {
+        "name": "ffi_type_uint32"
+      },
+      {
+        "name": "ffi_type_uint64"
+      },
+      {
+        "name": "ffi_type_uint8"
+      },
+      {
+        "name": "ffi_type_void"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "com.sun.jna.WString",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Boolean",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "boolean"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Byte",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "byte"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Character",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "char"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Class",
+    "methods": [
+      {
+        "name": "getComponentType",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Double",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "double"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Float",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "float"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Integer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Long",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "long"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Library$Handler"
+    },
+    "name": "java.lang.Object",
+    "methods": [
+      {
+        "name": "equals",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hashCode",
+        "parameterTypes": []
+      },
+      {
+        "name": "toString",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Object",
+    "methods": [
+      {
+        "name": "toString",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Short",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "short"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "name": "TYPE"
+      },
+      {
+        "name": "value"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.String",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "byte[]"
+        ]
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "byte[]",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "getBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getBytes",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "toCharArray",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.System",
+    "methods": [
+      {
+        "name": "getProperty",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.NativeLibrary"
+    },
+    "name": "java.lang.Throwable",
+    "methods": [
+      {
+        "name": "addSuppressed",
+        "parameterTypes": [
+          "java.lang.Throwable"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.Void",
+    "fields": [
+      {
+        "name": "TYPE"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.internal.ReflectionUtils"
+    },
+    "name": "java.lang.invoke.MethodHandle",
+    "methods": [
+      {
+        "name": "bindTo",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "invokeWithArguments",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.internal.ReflectionUtils"
+    },
+    "name": "java.lang.invoke.MethodHandles",
+    "methods": [
+      {
+        "name": "lookup",
+        "parameterTypes": []
+      },
+      {
+        "name": "privateLookupIn",
+        "parameterTypes": [
+          "java.lang.Class",
+          "java.lang.invoke.MethodHandles$Lookup"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.internal.ReflectionUtils"
+    },
+    "name": "java.lang.invoke.MethodHandles$Lookup",
+    "methods": [
+      {
+        "name": "findSpecial",
+        "parameterTypes": [
+          "java.lang.Class",
+          "java.lang.String",
+          "java.lang.invoke.MethodType",
+          "java.lang.Class"
+        ]
+      },
+      {
+        "name": "in",
+        "parameterTypes": [
+          "java.lang.Class"
+        ]
+      },
+      {
+        "name": "unreflectSpecial",
+        "parameterTypes": [
+          "java.lang.reflect.Method",
+          "java.lang.Class"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.internal.ReflectionUtils"
+    },
+    "name": "java.lang.invoke.MethodType",
+    "methods": [
+      {
+        "name": "methodType",
+        "parameterTypes": [
+          "java.lang.Class",
+          "java.lang.Class[]"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.lang.reflect.Method",
+    "methods": [
+      {
+        "name": "getParameterTypes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getReturnType",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.VarArgsChecker"
+    },
+    "name": "java.lang.reflect.Method",
+    "methods": [
+      {
+        "name": "isVarArgs",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.internal.ReflectionUtils"
+    },
+    "name": "java.lang.reflect.Method",
+    "methods": [
+      {
+        "name": "isDefault",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.Buffer",
+    "methods": [
+      {
+        "name": "position",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Platform"
+    },
+    "name": "java.nio.Buffer"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.ByteBuffer",
+    "methods": [
+      {
+        "name": "array",
+        "parameterTypes": []
+      },
+      {
+        "name": "arrayOffset",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.CharBuffer",
+    "methods": [
+      {
+        "name": "array",
+        "parameterTypes": []
+      },
+      {
+        "name": "arrayOffset",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.DoubleBuffer",
+    "methods": [
+      {
+        "name": "array",
+        "parameterTypes": []
+      },
+      {
+        "name": "arrayOffset",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.FloatBuffer",
+    "methods": [
+      {
+        "name": "array",
+        "parameterTypes": []
+      },
+      {
+        "name": "arrayOffset",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.IntBuffer",
+    "methods": [
+      {
+        "name": "array",
+        "parameterTypes": []
+      },
+      {
+        "name": "arrayOffset",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.LongBuffer",
+    "methods": [
+      {
+        "name": "array",
+        "parameterTypes": []
+      },
+      {
+        "name": "arrayOffset",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.nio.ShortBuffer",
+    "methods": [
+      {
+        "name": "array",
+        "parameterTypes": []
+      },
+      {
+        "name": "arrayOffset",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "java.security.SecureRandomParameters"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "sun.security.provider.NativePRNG",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.sun.jna.Native"
+    },
+    "name": "sun.security.provider.SHA",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.jna.platform.mac.SystemB$Timeval",
+    "allPublicConstructors": true,
+    "allPublicFields": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "oshi.jna.Struct$CloseableTimeval",
+    "allPublicConstructors": true
+  },
+  {
+    "name": "com.sun.jna.NativeLong",
+    "allPublicConstructors": true
+  },
+  {
+    "name": "oshi.jna.ByRef$CloseableULONGptrByReference",
+    "allPublicConstructors": true
+  },
+  {
+    "name": "oshi.jna.ByRef$CloseableHANDLEByReference",
+    "allPublicConstructors": true
+  },
+  {
+    "name": "oshi.jna.ByRef$CloseableNativeLongByReference",
+    "allPublicConstructors": true
+  },
+  {
+    "name": "oshi.jna.ByRef$CloseableLongByReference",
+    "allPublicConstructors": true
+  },
+  {
+    "name": "oshi.jna.ByRef$CloseableLONGLONGByReference",
+    "allPublicConstructors": true
+  },
+  {
+    "name": "oshi.jna.ByRef$CloseablePointerByReference",
+    "allPublicConstructors": true
+  },
+  {
+    "name": "oshi.jna.ByRef$CloseablePROCESSENTRY32ByReference",
+    "allPublicConstructors": true
+  },
+  {
+    "name": "oshi.jna.ByRef$CloseableIntByReference",
+    "allPublicConstructors": true
+  },
+  {
+    "name": "oshi.jna.ByRef$CloseableSizeTByReference",
+    "allPublicConstructors": true
+  },
+  {
+    "name": "com.sun.jna.platform.unix.LibCAPI$size_t",
+    "allPublicConstructors": true
+  },
+  {
+    "name": "com.sun.jna.platform.unix.LibCAPI$ssize_t",
+    "allPublicConstructors": true
+  }
+]


### PR DESCRIPTION
This switches the Kotlin/GraalVM uptime target to use OSHI on both macOS and Linux instead of shelling out or reading platform files directly. It wires  into the Bazel target and adds the reflection, JNI, proxy, and resource metadata needed for JNA/OSHI to run inside the GraalVM native image. Verified with  and by running 51096 successfully on macOS.