### PR TITLE
Add repo guidance to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Repo layout
+
+- Language-specific targets live under `//src/<lang>`.
+- When adding or changing an implementation, look in the matching `src/<lang>` directory first.
+
+## Required checks
+
+- If you change source files or any Bazel/Starlark files, run `bazel run //tools/format:format.check` before finishing.
+- Treat this as required for changes under `src/**`, `BUILD*`, `*.bzl`, and `MODULE.bazel`.
+
+## Branch workflow
+
+- When creating a branch for a new change, open a pull request immediately and keep the work attached to that PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 ## Required checks
 
 - If you change source files or any Bazel/Starlark files, run `bazel run //tools/format:format.check` before finishing.
+- If formatting changes are needed, run `bazel run //tools/format:format`.
 - Treat this as required for changes under `src/**`, `BUILD*`, `*.bzl`, and `MODULE.bazel`.
 
 ## Branch workflow


### PR DESCRIPTION
## Summary
- add a root AGENTS.md for repo-specific agent guidance
- document that language targets live under //src/<lang>
- require running bazel run //tools/format:format.check after source or Bazel/Starlark changes
- note that new change branches should get a PR opened immediately
