### PR TITLE
Use CI-only remote cache on macOS and Linux

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,9 +18,13 @@ build:macos --features=noop-this-is-because-we-have-no-config-flags-to-set-yet-o
 build:linux --features=swift.static_stdlib
 
 # Remote cache
-# Use my Tailnet's remote cache on Linux, but keep builds working if the cache
-# endpoint is unavailable.
-build:linux --remote_cache=grpc://bazel-remote.tailff30e.ts.net:9092
-build:linux --remote_local_fallback
-build:linux --incompatible_remote_local_fallback_for_remote_cache
-build:linux --remote_download_outputs=minimal
+# Only enable the internet-accessible remote cache in CI, but keep builds
+# working if the cache endpoint is unavailable.
+build:ci --remote_cache=grpcs://bazel-remote-ci.fly.dev:9092
+build:ci --remote_local_fallback
+build:ci --incompatible_remote_local_fallback_for_remote_cache
+build:ci --remote_download_outputs=minimal
+
+# Per-user and CI secret settings such as remote cache auth belong in a local rc
+# file so credentials are not committed.
+try-import %workspace%/user.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -24,7 +24,3 @@ build:ci --remote_cache=grpcs://bazel-remote-ci.fly.dev:9092
 build:ci --remote_local_fallback
 build:ci --incompatible_remote_local_fallback_for_remote_cache
 build:ci --remote_download_outputs=minimal
-
-# Per-user and CI secret settings such as remote cache auth belong in a local rc
-# file so credentials are not committed.
-try-import %workspace%/user.bazelrc

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,15 +10,15 @@ jobs:
   build:
     runs-on: ${{ inputs.runner }}
     steps:
-      - name: Tailscale
-        uses: tailscale/github-action@v4
-        with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci
-          version: latest
-        # Tailscale will probably never be able to auto-install on GitHub's macOS runners
-        if: runner.os == 'Linux'
+      # - name: Tailscale
+      #   uses: tailscale/github-action@v4
+      #   with:
+      #     oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+      #     oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+      #     tags: tag:ci
+      #     version: latest
+      #   # Tailscale will probably never be able to auto-install on GitHub's macOS runners
+      #   if: runner.os == 'Linux'
       - name: Git clone
         uses: actions/checkout@v6
       - name: Get cache path
@@ -32,6 +32,8 @@ jobs:
           path: ${{ steps.get-cache-path.outputs.bazel_repo_cache_path }}
           key: ${{ inputs.runner }}
       - name: Build
+        env:
+          REMOTE_CACHE_BASIC_AUTH_BASE64: ${{ secrets.REMOTE_CACHE_BASIC_AUTH_BASE64 }}
         run: ./script/build.sh
       - name: Stage compiled artifacts
         run: ./script/stage.sh

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ src/rs/target
 src/zig/zig-out
 uptime
 bazel-*
+user.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ src/rs/target
 src/zig/zig-out
 uptime
 bazel-*
-user.bazelrc

--- a/script/build.sh
+++ b/script/build.sh
@@ -18,14 +18,6 @@ fi
 # shellcheck source=deps.sh
 source ./script/deps.sh
 
-# If CI provides remote cache credentials, write them to the ignored local rc
-# file so Bazel can pick them up through the workspace try-import.
-if [[ -n "${CI:-}" && -n "${REMOTE_CACHE_BASIC_AUTH_BASE64:-}" ]]; then
-	cat <<EOF >user.bazelrc
-build:ci --remote_cache_header=Authorization=Basic ${REMOTE_CACHE_BASIC_AUTH_BASE64}
-EOF
-fi
-
 # Detect the highest available Xcode version on macOS
 XCODE_VERSION_FLAG=""
 if [[ "${PLATFORM}" == "macos" ]]; then
@@ -45,6 +37,9 @@ fi
 BAZEL_CONFIG_FLAGS=(--config="${PLATFORM}")
 if [[ -n "${CI:-}" ]]; then
 	BAZEL_CONFIG_FLAGS+=(--config=ci)
+fi
+if [[ -n "${CI:-}" && -n "${REMOTE_CACHE_BASIC_AUTH_BASE64:-}" ]]; then
+	BAZEL_CONFIG_FLAGS+=("--remote_cache_header=Authorization=Basic ${REMOTE_CACHE_BASIC_AUTH_BASE64}")
 fi
 
 bazel info "${BAZEL_CONFIG_FLAGS[@]}"

--- a/script/build.sh
+++ b/script/build.sh
@@ -18,6 +18,14 @@ fi
 # shellcheck source=deps.sh
 source ./script/deps.sh
 
+# If CI provides remote cache credentials, write them to the ignored local rc
+# file so Bazel can pick them up through the workspace try-import.
+if [[ -n "${CI:-}" && -n "${REMOTE_CACHE_BASIC_AUTH_BASE64:-}" ]]; then
+	cat <<EOF >user.bazelrc
+build:ci --remote_cache_header=Authorization=Basic ${REMOTE_CACHE_BASIC_AUTH_BASE64}
+EOF
+fi
+
 # Detect the highest available Xcode version on macOS
 XCODE_VERSION_FLAG=""
 if [[ "${PLATFORM}" == "macos" ]]; then
@@ -34,12 +42,17 @@ if [[ "${PLATFORM}" == "macos" ]]; then
 	echo "Detected Xcode version: ${highest_version}"
 fi
 
-bazel info
-bazel build --config="${PLATFORM}" ${XCODE_VERSION_FLAG:+"${XCODE_VERSION_FLAG}"} //...
+BAZEL_CONFIG_FLAGS=(--config="${PLATFORM}")
+if [[ -n "${CI:-}" ]]; then
+	BAZEL_CONFIG_FLAGS+=(--config=ci)
+fi
+
+bazel info "${BAZEL_CONFIG_FLAGS[@]}"
+bazel build "${BAZEL_CONFIG_FLAGS[@]}" ${XCODE_VERSION_FLAG:+"${XCODE_VERSION_FLAG}"} //...
 
 # At this point these are only lint-type checks
-bazel test --config="${PLATFORM}" --test_output=errors //...
+bazel test "${BAZEL_CONFIG_FLAGS[@]}" --test_output=errors //...
 
 for tgt in $(bazel query "${BINARIES_QUERY}"); do
-	bazel run --config=quiet --config="${PLATFORM}" "${tgt}"
+	bazel run --config=quiet "${BAZEL_CONFIG_FLAGS[@]}" "${tgt}"
 done


### PR DESCRIPTION
This switches Bazel to use the new grpcs remote cache only under --config=ci, so local builds keep their existing platform-only configs. CI now passes REMOTE_CACHE_BASIC_AUTH_BASE64 into the build, and script/build.sh writes an ignored user.bazelrc with a remote cache Authorization header when that env var is set. The old Tailscale login step remains in the workflow as commented-out YAML for reference. I also added user.bazelrc to .gitignore so cache credentials stay untracked.