### PR TITLE
Enable Renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,8 @@
         "schedule": [
             "every 1 weeks on Monday"
         ],
-        "groupName": "Lock file maintenance"
+        "groupName": "Lock file maintenance",
+        "automerge": true
     },
     "customManagers": [
         {
@@ -129,7 +130,8 @@
                 "patch",
                 "pin",
                 "digest"
-            ]
+            ],
+            "automerge": true
         }
     ]
 }


### PR DESCRIPTION
## Summary
- enable automerge for Renovate lock file maintenance PRs
- enable automerge for Renovate minor, patch, pin, and digest update PRs

## Testing
- jq empty renovate.json