### PR TITLE
[codex] Remove Renovate lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,14 +6,6 @@
     "schedule": [
         "every 1 weeks on Monday"
     ],
-    "lockFileMaintenance": {
-        "enabled": true,
-        "schedule": [
-            "every 1 weeks on Monday"
-        ],
-        "groupName": "Lock file maintenance",
-        "automerge": true
-    },
     "customManagers": [
         {
             "customType": "regex",
@@ -113,16 +105,6 @@
         }
     ],
     "packageRules": [
-        {
-            "description": "Keep lock file maintenance isolated",
-            "matchUpdateTypes": [
-                "lockFileMaintenance"
-            ],
-            "branchTopic": "lock-file-maintenance-{{{manager}}}",
-            "addLabels": [
-                "lockfile-maintenance"
-            ]
-        },
         {
             "groupName": "All updates",
             "matchUpdateTypes": [


### PR DESCRIPTION
## Summary

Removes Renovate's lock file maintenance configuration from `renovate.json`, including the dedicated package rule that matched `lockFileMaintenance` updates.

## Validation

- `bazel run //tools/format:format.check`