### PR TITLE
[codex] Fix Zig Renovate source for Codeberg

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -99,8 +99,9 @@
             "matchStrings": [
                 "zig\\.toolchain\\(zig_version\\s*=\\s*\"(?<currentValue>[^\"]+)\"\\)"
             ],
-            "datasourceTemplate": "github-releases",
+            "datasourceTemplate": "forgejo-tags",
             "depNameTemplate": "ziglang/zig",
+            "registryUrlTemplate": "https://codeberg.org",
             "versioningTemplate": "semver"
         }
     ],


### PR DESCRIPTION
## Summary

Update the custom Renovate manager for the Zig toolchain to read tags from Zig's Codeberg repository through Renovate's Forgejo datasource.

## Root cause

The manager used the `github-releases` datasource for `ziglang/zig`. Zig moved its repository and release tags to Codeberg, so Renovate could no longer discover future Zig toolchain versions.

## Impact

Renovate can discover stable Zig tags from `codeberg.org/ziglang/zig` and update `zig.toolchain(zig_version = ...)` in `MODULE.bazel` again.

## Validation

- Confirmed the Codeberg Forgejo API exposes semver tags for `ziglang/zig`
- `jq empty renovate.json`
- `npx --yes --package renovate@latest renovate-config-validator renovate.json`
- `git diff --check`
