### PR TITLE
Upgrade Zig toolchain and Bazel module dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -181,7 +181,7 @@ archive_override(
 bazel_dep(name = "rules_zig", version = "0.16.0")
 
 zig = use_extension("@rules_zig//zig:extensions.bzl", "zig")
-zig.toolchain(zig_version = "0.15.2")
+zig.toolchain(zig_version = "0.16.0")
 
 # formatting
 # (NOTE: we set up a lot of tool-specific repos here, wondering if we may be able to move

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -23,11 +23,11 @@
     "https://bcr.bazel.build/modules/apple_support/1.24.1/MODULE.bazel": "f46e8ddad60aef170ee92b2f3d00ef66c147ceafea68b6877cb45bd91737f5f8",
     "https://bcr.bazel.build/modules/apple_support/1.24.2/MODULE.bazel": "0e62471818affb9f0b26f128831d5c40b074d32e6dda5a0d3852847215a41ca4",
     "https://bcr.bazel.build/modules/apple_support/2.5.4/MODULE.bazel": "964e9268b37edb64e9a0fa525e5b5e535ba56bf63cadc68375f92e69fcb734f6",
-    "https://bcr.bazel.build/modules/apple_support/2.5.4/source.json": "df85e46410ff71c4006a13dbdeeeee488feba563be78f3a9ed8497c1fb93fb5d",
+    "https://bcr.bazel.build/modules/apple_support/2.6.1/MODULE.bazel": "b268db2f0642f6f2cb56fb08e3926ab6541b9996d9dd655b8c838b694e3ceeee",
+    "https://bcr.bazel.build/modules/apple_support/2.6.1/source.json": "50ab4c595cc21ff7c2fc3f1867ee098198b7cf11785b18ad96f1f519dc85ed69",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.31.2/MODULE.bazel": "7bee702b4862612f29333590f4b658a5832d433d6f8e4395f090e8f4e85d442f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "6307fec451ba9962c1c969eb516ebfe1e46528f7fa92e1c9ac8646bef4cdaa3f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.42.2/MODULE.bazel": "2e0d8ab25c57a14f56ace1c8e881b69050417ff91b2fb7718dc00d201f3c3478",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.0.0/MODULE.bazel": "e118477db5c49419a88d78ebc7a2c2cea9d49600fe0f490c1903324a2c16ecd9",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.13.0/MODULE.bazel": "af4a546cb88c618f2e241721d2d76b70b7ecfaa1d58fe27b9187d3edb9e418da",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.3/MODULE.bazel": "253d739ba126f62a5767d832765b12b59e9f8d2bc88cc1572f4a73e46eb298ca",
@@ -39,10 +39,10 @@
     "https://bcr.bazel.build/modules/aspect_rules_js/1.40.0/MODULE.bazel": "01a1014e95e6816b68ecee2584ae929c7d6a1b72e4333ab1ff2d2c6c30babdf1",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.40.0/source.json": "b6fd491369e9ef888fdef64b839023a2360caaea8eb370d2cfbfdd2a96721311",
     "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/MODULE.bazel": "e767c5dbfeb254ec03275a7701b5cfde2c4d2873676804bc7cb27ddff3728fed",
-    "https://bcr.bazel.build/modules/aspect_rules_lint/2.5.0/MODULE.bazel": "24f49acb3b8375fa138ba6ab53bcf517ae92529770a04ab04d47c958ff47b63e",
-    "https://bcr.bazel.build/modules/aspect_rules_lint/2.5.0/source.json": "8beadb1db5fa4b5e36769a5247c200a877fbc9f397dc10b5aa33e76099483070",
-    "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.2.8/MODULE.bazel": "aa975a83e72bcaac62ee61ab12b788ea324a1d05c4aab28aadb202f647881679",
-    "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.2.8/source.json": "786cbc49377fb6bf4859aec5b1c61f8fc26b08e9fdb929e2dde2e1e2a406bd24",
+    "https://bcr.bazel.build/modules/aspect_rules_lint/2.7.1/MODULE.bazel": "52f070e52379d262523676b6c5db430b6615849c68c001c3e16d72c6ac411b18",
+    "https://bcr.bazel.build/modules/aspect_rules_lint/2.7.1/source.json": "afc63f90e4fbcdcb9ec01a472609b8b778efb86156ae34ff4a58a1a2262489d7",
+    "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/MODULE.bazel": "37c764292861c2f70314efa9846bb6dbb44fc0308903b3285da6528305450183",
+    "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/source.json": "605086bbc197743a0d360f7ddc550a1d4dfa0441bc807236e17170f636153348",
     "https://bcr.bazel.build/modules/bazel_features/0.1.0/MODULE.bazel": "47011d645b0f949f42ee67f2e8775188a9cf4a0a1528aa2fa4952f2fd00906fd",
     "https://bcr.bazel.build/modules/bazel_features/1.0.0/MODULE.bazel": "d7f022dc887efb96e1ee51cec7b2e48d41e36ff59a6e4f216c40e4029e1585bf",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
@@ -66,7 +66,8 @@
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.42.1/MODULE.bazel": "275a59b5406ff18c01739860aa70ad7ccb3cfb474579411decca11c93b951080",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
-    "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",
+    "https://bcr.bazel.build/modules/bazel_features/1.47.0/MODULE.bazel": "e34df3cb35b1684cfa69923a61ae3803595babd3942cd306a488d51400886b30",
+    "https://bcr.bazel.build/modules/bazel_features/1.47.0/source.json": "4ba0b5138327f2d73352a51547a4e49a0a828ef400e046b15334d8905bf6b7ff",
     "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_lib/3.0.0-rc.0/MODULE.bazel": "d6e00979a98ac14ada5e31c8794708b41434d461e7e7ca39b59b765e6d233b18",
@@ -90,12 +91,12 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/MODULE.bazel": "72997b29dfd95c3fa0d0c48322d05590418edef451f8db8db5509c57875fb4b7",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/source.json": "7ad77c1e8c1b84222d9b3f3cae016a76639435744c19330b0b37c0a3c9da7dc0",
     "https://bcr.bazel.build/modules/bazel_worker_api/0.0.1/MODULE.bazel": "02a13b77321773b2042e70ee5e4c5e099c8ddee4cf2da9cd420442c36938d4bd",
-    "https://bcr.bazel.build/modules/bazel_worker_api/0.0.10/MODULE.bazel": "a426df551b40c3997c351d05f00f0d1f86b618ddb646012f1e9c72efce8ed939",
-    "https://bcr.bazel.build/modules/bazel_worker_api/0.0.10/source.json": "7f220d3edfeba5d1f61535fd8400338df74f8bdeb241ebe660534c6926a5a645",
+    "https://bcr.bazel.build/modules/bazel_worker_api/0.0.11/MODULE.bazel": "fe09a8d3fb25c95414249f72cb0936201bf7e3c3f0e302175b2fc81e68bc6069",
+    "https://bcr.bazel.build/modules/bazel_worker_api/0.0.11/source.json": "7867c70965fccd202c57796de69fcbdf0555da34e3b09a14b06d74afb0f2f26d",
     "https://bcr.bazel.build/modules/bazel_worker_api/0.0.4/MODULE.bazel": "460aa12d01231a80cce03c548287b433b321d205b0028ae596728c35e5ee442e",
     "https://bcr.bazel.build/modules/bazel_worker_api/0.0.8/MODULE.bazel": "396c1ef53835aafe3d42ce6619080531ee770648303731f16cfaa33fa056bf0c",
-    "https://bcr.bazel.build/modules/bazel_worker_java/0.0.10/MODULE.bazel": "538f21f715cab81c4a43f73e1a91a0c1f8accd9b263dd2a831952805fcfc1a62",
-    "https://bcr.bazel.build/modules/bazel_worker_java/0.0.10/source.json": "1646d3aaf5a4bc0d587ecb33d81e93ea9284ff96f5ef579006a9c054945bbe7a",
+    "https://bcr.bazel.build/modules/bazel_worker_java/0.0.11/MODULE.bazel": "1ee9e4c28ce455dbacdff8e007e133ea209e6f673a9e97cf20e99b161bc17548",
+    "https://bcr.bazel.build/modules/bazel_worker_java/0.0.11/source.json": "48b9b9c55f69cc360a54a712f47b889dd3d367ce2d45c3ccec242e9af86fe9cd",
     "https://bcr.bazel.build/modules/bazel_worker_java/0.0.4/MODULE.bazel": "82494a01018bb7ef06d4a17ec4cd7a758721f10eb8b6c820a818e70d669500db",
     "https://bcr.bazel.build/modules/bazel_worker_java/0.0.8/MODULE.bazel": "e76479eae70bd4e8f5f4c2dfc5d03ab971cfb18750246c7b3f3454c5c2ee6629",
     "https://bcr.bazel.build/modules/buildifier_prebuilt/6.4.0/MODULE.bazel": "37389c6b5a40c59410b4226d3bb54b08637f393d66e2fa57925c6fcf68e64bf4",
@@ -119,8 +120,8 @@
     "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
     "https://bcr.bazel.build/modules/gazelle/0.40.0/MODULE.bazel": "42ba5378ebe845fca43989a53186ab436d956db498acde790685fe0e8f9c6146",
     "https://bcr.bazel.build/modules/gazelle/0.47.0/MODULE.bazel": "b61bb007c4efad134aa30ee7f4a8e2a39b22aa5685f005edaa022fbd1de43ebc",
-    "https://bcr.bazel.build/modules/gazelle/0.50.0/MODULE.bazel": "5dce69aa1d7b5bc85d1e1cfe61f0a9a27426c46425ec1d064685f941a5977329",
-    "https://bcr.bazel.build/modules/gazelle/0.50.0/source.json": "3cadcd284172c4274dc44c71b571f08ec4f22b28d5e9ad2708347c6e6c3a41b9",
+    "https://bcr.bazel.build/modules/gazelle/0.51.3/MODULE.bazel": "618a729142f66de1e2cb776d026413763be5b80d5e3d29ffb9d3d90c5defde90",
+    "https://bcr.bazel.build/modules/gazelle/0.51.3/source.json": "fbe5312a01fb4a2a58caff4a0d40dcf384b6f0bda75e85546663360da1d7538a",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
@@ -152,7 +153,8 @@
     "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
     "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
     "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
-    "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
+    "https://bcr.bazel.build/modules/platforms/1.1.0/MODULE.bazel": "1c0c09f5bdcf4b3f924720d2478a3711cb39f4977019ca5988685e5b7e18b3d2",
+    "https://bcr.bazel.build/modules/platforms/1.1.0/source.json": "fcf351c47596c939140ab0d333dfdd08ed1ea6ce33c2fe70c12493a301cf1344",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/23.1/MODULE.bazel": "88b393b3eb4101d18129e5db51847cd40a5517a53e81216144a8c32dfeeca52a",
     "https://bcr.bazel.build/modules/protobuf/24.4/MODULE.bazel": "7bc7ce5f2abf36b3b7b7c8218d3acdebb9426aeb35c2257c96445756f970eb12",
@@ -185,8 +187,8 @@
     "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
     "https://bcr.bazel.build/modules/rules_android/0.6.4/MODULE.bazel": "b4cde12d506dd65d82b2be39761f49f5797303343a3d5b4ee191c0cdf9ef387c",
     "https://bcr.bazel.build/modules/rules_android/0.7.1/MODULE.bazel": "a806fc382a774252f228a40e3b11b9fcc6276f8778c7fb33e9f72937c6258363",
-    "https://bcr.bazel.build/modules/rules_android/0.7.2/MODULE.bazel": "0862d727582c8d117ac09cd3451b5e93d8b91033f0f13bb61a4a10334958130d",
-    "https://bcr.bazel.build/modules/rules_android/0.7.2/source.json": "bf2dfc8dc72ffd2b58643c9d547f1b7faea4de65aa28ac4894687fa6afa09861",
+    "https://bcr.bazel.build/modules/rules_android/0.7.3/MODULE.bazel": "1fbc49fb397d31d74be83fe63eb0a5dc1a79df172ca90772166c35ab4cd67e7b",
+    "https://bcr.bazel.build/modules/rules_android/0.7.3/source.json": "80ffccd224a7f9b665f32360a64ba4228ba85c75fd0f6af43e290660147bb151",
     "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
     "https://bcr.bazel.build/modules/rules_apple/4.1.0/MODULE.bazel": "76e10fd4a48038d3fc7c5dc6e63b7063bbf5304a2e3bd42edda6ec660eebea68",
     "https://bcr.bazel.build/modules/rules_apple/4.1.0/source.json": "8ee81e1708756f81b343a5eb2b2f0b953f1d25c4ab3d4a68dc02754872e80715",
@@ -213,7 +215,8 @@
     "https://bcr.bazel.build/modules/rules_cc/0.2.16/MODULE.bazel": "9242fa89f950c6ef7702801ab53922e99c69b02310c39fb6e62b2bd30df2a1d4",
     "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
     "https://bcr.bazel.build/modules/rules_cc/0.2.18/MODULE.bazel": "4460ec36adc8f722a6a2a4ac9374cb91f2acebadaa93fc37966129afb3dece87",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.18/source.json": "abad668ff2fd63ada1ac49bf386d37e27048b89a3465a6fd968bb832b00a09d3",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.19/MODULE.bazel": "d5e0f05b63273281a16654eb6b1a8742a75ec153ac8b4f0419949d6e401e46f0",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.19/source.json": "1ef48cdbd7aa6238015189b582d3d74ef0cbea3cb3e2cb259d782463f570c14a",
     "https://bcr.bazel.build/modules/rules_cc/0.2.4/MODULE.bazel": "1ff1223dfd24f3ecf8f028446d4a27608aa43c3f41e346d22838a4223980b8cc",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
     "https://bcr.bazel.build/modules/rules_cc/0.2.9/MODULE.bazel": "34263f1dca62ea664265438cef714d7db124c03e1ed55ebb4f1dc860164308d1",
@@ -231,8 +234,8 @@
     "https://bcr.bazel.build/modules/rules_go/0.51.0-rc2/MODULE.bazel": "edfc3a9cea7bedb0eaaff37b0d7817c1a4bf72b3c615580b0ffcee6c52690fd4",
     "https://bcr.bazel.build/modules/rules_go/0.53.0/MODULE.bazel": "a4ed760d3ac0dbc0d7b967631a9a3fd9100d28f7d9fcf214b4df87d4bfff5f9a",
     "https://bcr.bazel.build/modules/rules_go/0.59.0/MODULE.bazel": "b7e43e7414a3139a7547d1b4909b29085fbe5182b6c58cbe1ed4c6272815aeae",
-    "https://bcr.bazel.build/modules/rules_go/0.60.0/MODULE.bazel": "4a57ff2ffc2a3570e3c5646575c5a4b07287e91bcdac5d1f72383d51502b48cb",
-    "https://bcr.bazel.build/modules/rules_go/0.60.0/source.json": "1e21368c5e0c3013a110bd79a8fcff8ca46b5bcb2b561713a7273cbfcff7c464",
+    "https://bcr.bazel.build/modules/rules_go/0.61.1/MODULE.bazel": "b599cc67f98e8dbe040631129fbd23f190a557f7be506d4781619d0fd4dbbbec",
+    "https://bcr.bazel.build/modules/rules_go/0.61.1/source.json": "ff52d46fca8e2ac87c610c11f05c3a9f0fa08dc4294664c6a31449092409c5aa",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
     "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
@@ -315,13 +318,12 @@
     "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
     "https://bcr.bazel.build/modules/rules_python/1.6.3/MODULE.bazel": "a7b80c42cb3de5ee2a5fa1abc119684593704fcd2fec83165ebe615dec76574f",
     "https://bcr.bazel.build/modules/rules_python/1.7.0/MODULE.bazel": "d01f995ecd137abf30238ad9ce97f8fc3ac57289c8b24bd0bf53324d937a14f8",
-    "https://bcr.bazel.build/modules/rules_python/2.0.0/MODULE.bazel": "1459089e2d4194d2a49e07896f5334fb230a8f2966ae945b1f793bef87a292fd",
-    "https://bcr.bazel.build/modules/rules_python/2.0.0/source.json": "b8e25661f58c573e5e27af21295867e87766e89211f326fcb84034e6e6b6794b",
+    "https://bcr.bazel.build/modules/rules_python/2.0.3/MODULE.bazel": "19679690907c56be16fe992643e618400be778605d373a386dbe5474313b8e60",
+    "https://bcr.bazel.build/modules/rules_python/2.0.3/source.json": "bca9b3ddd8fc8c8cab08be3cfaa011fefc3d5b48d7695624e7f536e64def57e0",
     "https://bcr.bazel.build/modules/rules_robolectric/4.14.1.2/MODULE.bazel": "d44fec647d0aeb67b9f3b980cf68ba634976f3ae7ccd6c07d790b59b87a4f251",
     "https://bcr.bazel.build/modules/rules_robolectric/4.14.1.2/source.json": "37c10335f2361c337c5c1f34ed36d2da70534c23088062b33a8bdaab68aa9dea",
     "https://bcr.bazel.build/modules/rules_ruby/0.27.0/MODULE.bazel": "3c945acc1d758f9572da30a47f964ddc439fb9430dedff3b48d37cd2098fb051",
     "https://bcr.bazel.build/modules/rules_ruby/0.27.0/source.json": "78670cee4496a4cb692d248440078c5d2ef2c130315b86a4ccabc0cd7016506c",
-    "https://bcr.bazel.build/modules/rules_rust/0.67.0/MODULE.bazel": "87c3816c4321352dcfd9e9e26b58e84efc5b21351ae3ef8fb5d0d57bde7237f5",
     "https://bcr.bazel.build/modules/rules_rust/0.70.0/MODULE.bazel": "5b1407b11c305bc2522e204e7f170faf8399e836e49b6afef9074dfe532e6c3f",
     "https://bcr.bazel.build/modules/rules_rust/0.70.0/source.json": "24ae6d23425359db1c3148aa22c389970fce9a06102b2b3a329a2800f9569de2",
     "https://bcr.bazel.build/modules/rules_shell/0.1.2/MODULE.bazel": "66e4ca3ce084b04af0b9ff05ff14cab4e5df7503973818bb91cbc6cda08d32fc",
@@ -331,8 +333,8 @@
     "https://bcr.bazel.build/modules/rules_shell/0.5.0/MODULE.bazel": "8c8447370594d45539f66858b602b0bb2cb2d3401a4ebb9ad25830c59c0f366d",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/source.json": "20ec05cd5e592055e214b2da8ccb283c7f2a421ea0dc2acbf1aa792e11c03d0c",
-    "https://bcr.bazel.build/modules/rules_zig/0.13.0/MODULE.bazel": "e9f20d33c56eb32e94155dae8d4c877314d049d80863cc217e9c69aa7ccf8057",
-    "https://bcr.bazel.build/modules/rules_zig/0.13.0/source.json": "f3e42705f21c282f0653dbac6f59de385ee148c6cea7faf4d658eb663d2fcacb",
+    "https://bcr.bazel.build/modules/rules_zig/0.16.0/MODULE.bazel": "38b7547893292794874d9e30a1f18aac82d8a4a8c83e766c1b07178ced6b3650",
+    "https://bcr.bazel.build/modules/rules_zig/0.16.0/source.json": "6f2eaccdbdee823c53b803fa28b73f435808644ab2818da11e3ce26617804493",
     "https://bcr.bazel.build/modules/stardoc/0.5.0/MODULE.bazel": "f9f1f46ba8d9c3362648eea571c6f9100680efc44913618811b58cc9c02cd678",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
@@ -430,10 +432,10 @@
     },
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
-        "bzlTransitiveDigest": "gA7tPEdJXhskzPIEUxjX9IdDrM6+WjfbgXJ8Ez47umk=",
-        "usagesDigest": "Qe1lA0prPNt87OXoXq3fzmffG9RmcuqdmLdwKVAOUnc=",
+        "bzlTransitiveDigest": "cl5A2O84vDL6Tt+Qga8FCj1DUDGqn+e7ly5rZ+4xvcc=",
+        "usagesDigest": "tiZsmifkpLM+xnn6EXkTF48bYLsbvhr5rcGkv4SuImc=",
         "recordedInputs": [
-          "REPO_MAPPING:aspect_tools_telemetry+,aspect_bazel_lib aspect_bazel_lib+",
+          "REPO_MAPPING:aspect_tools_telemetry+,bazel_lib bazel_lib+",
           "REPO_MAPPING:aspect_tools_telemetry+,bazel_skylib bazel_skylib+"
         ],
         "generatedRepoSpecs": {
@@ -441,8 +443,8 @@
             "repoRuleId": "@@aspect_tools_telemetry+//:extension.bzl%tel_repository",
             "attributes": {
               "deps": {
-                "aspect_rules_lint": "2.5.0",
-                "aspect_tools_telemetry": "0.2.8"
+                "aspect_rules_lint": "2.7.1",
+                "aspect_tools_telemetry": "0.3.3"
               }
             }
           }
@@ -507,7 +509,7 @@
     "@@rules_android+//rules/android_sdk_repository:rule.bzl%android_sdk_repository_extension": {
       "general": {
         "bzlTransitiveDigest": "qHbR00gVzVzkxX+PRtv4UGcUFMtBz7TK9CNYUWH8nIE=",
-        "usagesDigest": "tTIw/WMyb1t/LzacDY8lDjUznzxQ3MyXW6474WIS3WQ=",
+        "usagesDigest": "x1HLqlqAwv0KTxojlsMXLqzK2rEGmh0n16qUmbSgEak=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "androidsdk": {
@@ -803,7 +805,7 @@
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
         "bzlTransitiveDigest": "I8FPZMevE2oI/peSpMBRVIN++WOtfjtJVjbPsBZQ87A=",
-        "usagesDigest": "DwZ4Bamg/skxdi0sa765qXLDi4cL9PQbmLkE7jwQKVU=",
+        "usagesDigest": "XGwR3eTI95rhVlQBWeWHCf6MeLufEzhWrWRWAtF6Zv4=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
           "REPO_MAPPING:rules_python+,platforms platforms"
@@ -987,18 +989,18 @@
     },
     "@@rules_zig+//zig:extensions.bzl%zig": {
       "general": {
-        "bzlTransitiveDigest": "2N/bPP3F/BmxIlsKg+Bpt+Klpwy9jlN2xuKqIRFIhZw=",
-        "usagesDigest": "+QD2cylZE+by/KlxVd1hGIOzWxm9fTOllyXlaB0HrqY=",
+        "bzlTransitiveDigest": "8E8c6wjQpII8BlqmFJDak9wmxG+0LIn8BNzJs69Fez8=",
+        "usagesDigest": "RqHgCVxc/c0MLKj1VCqtnoFDvU4cS9pJXKMXg5crckc=",
         "recordedInputs": [
           "REPO_MAPPING:rules_zig+,bazel_skylib bazel_skylib+",
           "REPO_MAPPING:rules_zig+,bazel_tools bazel_tools",
-          "FILE:@@rules_zig+//zig/private/versions.json be9e64e6d54b73fab50f32ea3c39e9f74b1fdf317fc1deef13aaf17c435ba3db"
+          "FILE:@@rules_zig+//zig/private/versions.json 5d4313a411f05e581e74a08ff333a229289434dc15c6f4f1de1db09076d4aa81"
         ],
         "generatedRepoSpecs": {
-          "zig_0.15.2_aarch64-linux": {
+          "zig_0.16.0_aarch64-linux": {
             "repoRuleId": "@@rules_zig+//zig/private/repo:zig_repository.bzl%zig_repository",
             "attributes": {
-              "url": "https://ziglang.org/download/0.15.2/zig-aarch64-linux-0.15.2.tar.xz",
+              "url": "https://ziglang.org/download/0.16.0/zig-aarch64-linux-0.16.0.tar.xz",
               "mirrors": [
                 "https://pkg.machengine.org/zig",
                 "https://zigmirror.hryx.net/zig",
@@ -1014,15 +1016,15 @@
                 "https://pkg.earth/zig",
                 "https://fs.liujiacai.net/zigbuilds"
               ],
-              "sha256": "958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f",
-              "zig_version": "0.15.2",
+              "sha256": "ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17",
+              "zig_version": "0.16.0",
               "platform": "aarch64-linux"
             }
           },
-          "zig_0.15.2_aarch64-macos": {
+          "zig_0.16.0_aarch64-macos": {
             "repoRuleId": "@@rules_zig+//zig/private/repo:zig_repository.bzl%zig_repository",
             "attributes": {
-              "url": "https://ziglang.org/download/0.15.2/zig-aarch64-macos-0.15.2.tar.xz",
+              "url": "https://ziglang.org/download/0.16.0/zig-aarch64-macos-0.16.0.tar.xz",
               "mirrors": [
                 "https://pkg.machengine.org/zig",
                 "https://zigmirror.hryx.net/zig",
@@ -1038,15 +1040,15 @@
                 "https://pkg.earth/zig",
                 "https://fs.liujiacai.net/zigbuilds"
               ],
-              "sha256": "3cc2bab367e185cdfb27501c4b30b1b0653c28d9f73df8dc91488e66ece5fa6b",
-              "zig_version": "0.15.2",
+              "sha256": "b23d70deaa879b5c2d486ed3316f7eaa53e84acf6fc9cc747de152450d401489",
+              "zig_version": "0.16.0",
               "platform": "aarch64-macos"
             }
           },
-          "zig_0.15.2_aarch64-windows": {
+          "zig_0.16.0_aarch64-windows": {
             "repoRuleId": "@@rules_zig+//zig/private/repo:zig_repository.bzl%zig_repository",
             "attributes": {
-              "url": "https://ziglang.org/download/0.15.2/zig-aarch64-windows-0.15.2.zip",
+              "url": "https://ziglang.org/download/0.16.0/zig-aarch64-windows-0.16.0.zip",
               "mirrors": [
                 "https://pkg.machengine.org/zig",
                 "https://zigmirror.hryx.net/zig",
@@ -1062,15 +1064,15 @@
                 "https://pkg.earth/zig",
                 "https://fs.liujiacai.net/zigbuilds"
               ],
-              "sha256": "b926465f8872bf983422257cd9ec248bb2b270996fbe8d57872cca13b56fc370",
-              "zig_version": "0.15.2",
+              "sha256": "aee38316ee4111717900f45dd3130145c39289e105541d737eb8c5ed653c78ef",
+              "zig_version": "0.16.0",
               "platform": "aarch64-windows"
             }
           },
-          "zig_0.15.2_x86_64-linux": {
+          "zig_0.16.0_x86_64-linux": {
             "repoRuleId": "@@rules_zig+//zig/private/repo:zig_repository.bzl%zig_repository",
             "attributes": {
-              "url": "https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz",
+              "url": "https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz",
               "mirrors": [
                 "https://pkg.machengine.org/zig",
                 "https://zigmirror.hryx.net/zig",
@@ -1086,15 +1088,15 @@
                 "https://pkg.earth/zig",
                 "https://fs.liujiacai.net/zigbuilds"
               ],
-              "sha256": "02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239",
-              "zig_version": "0.15.2",
+              "sha256": "70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00",
+              "zig_version": "0.16.0",
               "platform": "x86_64-linux"
             }
           },
-          "zig_0.15.2_x86_64-macos": {
+          "zig_0.16.0_x86_64-macos": {
             "repoRuleId": "@@rules_zig+//zig/private/repo:zig_repository.bzl%zig_repository",
             "attributes": {
-              "url": "https://ziglang.org/download/0.15.2/zig-x86_64-macos-0.15.2.tar.xz",
+              "url": "https://ziglang.org/download/0.16.0/zig-x86_64-macos-0.16.0.tar.xz",
               "mirrors": [
                 "https://pkg.machengine.org/zig",
                 "https://zigmirror.hryx.net/zig",
@@ -1110,15 +1112,15 @@
                 "https://pkg.earth/zig",
                 "https://fs.liujiacai.net/zigbuilds"
               ],
-              "sha256": "375b6909fc1495d16fc2c7db9538f707456bfc3373b14ee83fdd3e22b3d43f7f",
-              "zig_version": "0.15.2",
+              "sha256": "0387557ed1877bc6a2e1802c8391953baddba76081876301c522f52977b52ba7",
+              "zig_version": "0.16.0",
               "platform": "x86_64-macos"
             }
           },
-          "zig_0.15.2_x86_64-windows": {
+          "zig_0.16.0_x86_64-windows": {
             "repoRuleId": "@@rules_zig+//zig/private/repo:zig_repository.bzl%zig_repository",
             "attributes": {
-              "url": "https://ziglang.org/download/0.15.2/zig-x86_64-windows-0.15.2.zip",
+              "url": "https://ziglang.org/download/0.16.0/zig-x86_64-windows-0.16.0.zip",
               "mirrors": [
                 "https://pkg.machengine.org/zig",
                 "https://zigmirror.hryx.net/zig",
@@ -1134,8 +1136,8 @@
                 "https://pkg.earth/zig",
                 "https://fs.liujiacai.net/zigbuilds"
               ],
-              "sha256": "3a0ed1e8799a2f8ce2a6e6290a9ff22e6906f8227865911fb7ddedc3cc14cb0c",
-              "zig_version": "0.15.2",
+              "sha256": "68659eb5f1e4eb1437a722f1dd889c5a322c9954607f5edcf337bc3684a75a7e",
+              "zig_version": "0.16.0",
               "platform": "x86_64-windows"
             }
           },
@@ -1143,28 +1145,28 @@
             "repoRuleId": "@@rules_zig+//zig/private/repo:toolchains_repo.bzl%toolchains_repo",
             "attributes": {
               "names": [
-                "zig_0.15.2_aarch64-linux",
-                "zig_0.15.2_aarch64-macos",
-                "zig_0.15.2_aarch64-windows",
-                "zig_0.15.2_x86_64-linux",
-                "zig_0.15.2_x86_64-macos",
-                "zig_0.15.2_x86_64-windows"
+                "zig_0.16.0_aarch64-linux",
+                "zig_0.16.0_aarch64-macos",
+                "zig_0.16.0_aarch64-windows",
+                "zig_0.16.0_x86_64-linux",
+                "zig_0.16.0_x86_64-macos",
+                "zig_0.16.0_x86_64-windows"
               ],
               "labels": [
-                "@zig_0.15.2_aarch64-linux//:zig_toolchain",
-                "@zig_0.15.2_aarch64-macos//:zig_toolchain",
-                "@zig_0.15.2_aarch64-windows//:zig_toolchain",
-                "@zig_0.15.2_x86_64-linux//:zig_toolchain",
-                "@zig_0.15.2_x86_64-macos//:zig_toolchain",
-                "@zig_0.15.2_x86_64-windows//:zig_toolchain"
+                "@zig_0.16.0_aarch64-linux//:zig_toolchain",
+                "@zig_0.16.0_aarch64-macos//:zig_toolchain",
+                "@zig_0.16.0_aarch64-windows//:zig_toolchain",
+                "@zig_0.16.0_x86_64-linux//:zig_toolchain",
+                "@zig_0.16.0_x86_64-macos//:zig_toolchain",
+                "@zig_0.16.0_x86_64-windows//:zig_toolchain"
               ],
               "zig_versions": [
-                "0.15.2",
-                "0.15.2",
-                "0.15.2",
-                "0.15.2",
-                "0.15.2",
-                "0.15.2"
+                "0.16.0",
+                "0.16.0",
+                "0.16.0",
+                "0.16.0",
+                "0.16.0",
+                "0.16.0"
               ],
               "exec_lengths": [
                 2,
@@ -1187,7 +1189,48 @@
                 "@platforms//cpu:x86_64",
                 "@platforms//os:windows",
                 "@platforms//cpu:x86_64"
-              ]
+              ],
+              "target_compatible_lengths": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+              ],
+              "target_compatible_constraints": [],
+              "target_settings_lengths": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+              ],
+              "target_settings": []
+            }
+          }
+        }
+      }
+    },
+    "@@rules_zig+//zig/zls:extensions.bzl%zls": {
+      "general": {
+        "bzlTransitiveDigest": "eQUCowuh3A1sne3rXIfP4c/zG6G3oEkvOeweLxDSlKY=",
+        "usagesDigest": "JDD0Ysbvn6dZW16rSnpZTa9IQNOjx1F0W11Ep16srWA=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_zig+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:rules_zig+,bazel_tools bazel_tools",
+          "FILE:@@rules_zig+//zig/zls/private/versions.json 48e3b0b5a31f2a77350dd6c872984850011577de3d77dc7de9ae05565aa8451f"
+        ],
+        "generatedRepoSpecs": {
+          "zls_toolchains": {
+            "repoRuleId": "@@rules_zig+//zig/zls/private/repo:toolchains_repo.bzl%toolchains_repo",
+            "attributes": {
+              "names": [],
+              "labels": [],
+              "zig_versions": [],
+              "exec_lengths": [],
+              "exec_constraints": []
             }
           }
         }
@@ -1737,162 +1780,162 @@
           "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
         ]
       },
-      "1.26.2": {
+      "1.26.4": {
         "aix_ppc64": [
-          "go1.26.2.aix-ppc64.tar.gz",
-          "e6f759fbdd5b1e3ecce3161d8bd9b9aeaf15c4112b7c101097e9d329b310d858"
+          "go1.26.4.aix-ppc64.tar.gz",
+          "881bf44c07203fc1759d477412c2dfae425e5d2023acdd79299d5de5b4de8e77"
         ],
         "darwin_amd64": [
-          "go1.26.2.darwin-amd64.tar.gz",
-          "bc3f1500d9968c36d705442d90ba91addf9271665033748b82532682e90a7966"
+          "go1.26.4.darwin-amd64.tar.gz",
+          "05dc9b5f9997744520aaebb3d5deaa7c755371aebbfb7f97c2511a9f3367538d"
         ],
         "darwin_arm64": [
-          "go1.26.2.darwin-arm64.tar.gz",
-          "32af1522bf3e3ff3975864780a429cc0b41d190ec7bf90faa661d6d64566e7af"
+          "go1.26.4.darwin-arm64.tar.gz",
+          "b62ad2b6d7d2464f12a5bcad7ff47f19d08325773b5efd21610e445a05a9bf53"
         ],
         "dragonfly_amd64": [
-          "go1.26.2.dragonfly-amd64.tar.gz",
-          "b4f3f74412914e54140cbf8b5c76d2f8eeff3a5003310c9244c61ba8a0ecd94b"
+          "go1.26.4.dragonfly-amd64.tar.gz",
+          "bcc3ee1cfb6dd03a2d5abf07174212df1764ae54406c389b71a7fd2d05a8f0c8"
         ],
         "freebsd_386": [
-          "go1.26.2.freebsd-386.tar.gz",
-          "fab09ea1988aae3ae2c8186455e8956d539d04e2ee4973e8887853432d0e8039"
+          "go1.26.4.freebsd-386.tar.gz",
+          "f4325e0f9a5894e79c60b5e692af55a1e6f261b8ea73dcd20eced8372ad08233"
         ],
         "freebsd_amd64": [
-          "go1.26.2.freebsd-amd64.tar.gz",
-          "f271fd829a2a6b36fa1c72cdaafb18410a106da982c93a626d4e8b0fa0f0fa21"
+          "go1.26.4.freebsd-amd64.tar.gz",
+          "e91e96c0d3bd8f770e5a0facaf21d010a84e1c9440d830210cb3c223f0b7fb50"
         ],
         "freebsd_arm": [
-          "go1.26.2.freebsd-arm.tar.gz",
-          "38713f1516cd2b0097ea05594ec1c842fe690dace8301c7d34d91b92250b4424"
+          "go1.26.4.freebsd-arm.tar.gz",
+          "36e45b3a843087f0f95a71f2ed453ea7e1727e684644d13f8b4c6c93fd977d41"
         ],
         "freebsd_arm64": [
-          "go1.26.2.freebsd-arm64.tar.gz",
-          "d78bb171900134efdd1d0d49e5e80cd8c8b614f0e46c508d0b6bac30fb996fdf"
+          "go1.26.4.freebsd-arm64.tar.gz",
+          "34aee1071d74cc23703d1b415c5fa44f840d29fd3733dac34944d83cfada3ff3"
         ],
         "illumos_amd64": [
-          "go1.26.2.illumos-amd64.tar.gz",
-          "e88cd85e9e253ceda4077367072aa10d2f92bc2fa6e59a811c00bbe95dc9b02d"
+          "go1.26.4.illumos-amd64.tar.gz",
+          "27603bcd431afab272a5ed81cc951146181e8139640c46ed2ea5b560e1097038"
         ],
         "linux_386": [
-          "go1.26.2.linux-386.tar.gz",
-          "89835cdc4dfebde7fe28c9c6dc080bb3753f6b0354301966ff9f62d14991bd7d"
+          "go1.26.4.linux-386.tar.gz",
+          "5ca0982791791559d11a0eba939617a94c3f37c21aa514a55c415b9167efc658"
         ],
         "linux_amd64": [
-          "go1.26.2.linux-amd64.tar.gz",
-          "990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282"
+          "go1.26.4.linux-amd64.tar.gz",
+          "1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f"
         ],
         "linux_arm64": [
-          "go1.26.2.linux-arm64.tar.gz",
-          "c958a1fe1b361391db163a485e21f5f228142d6f8b584f6bef89b26f66dc5b23"
+          "go1.26.4.linux-arm64.tar.gz",
+          "ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768"
         ],
         "linux_armv6l": [
-          "go1.26.2.linux-armv6l.tar.gz",
-          "0000e45577827b0a8868588c543cbe4232853def1d3d7a344ad6e60ce2b015c8"
+          "go1.26.4.linux-armv6l.tar.gz",
+          "8db458e995f18a9427a745cefe7a3323962fa2548c4715148963311f300d3b1a"
         ],
         "linux_loong64": [
-          "go1.26.2.linux-loong64.tar.gz",
-          "4dcb87e845fe5c015c8cf6affb4636fcf1699182b70454783caed85c5dfa3267"
+          "go1.26.4.linux-loong64.tar.gz",
+          "9f6d288d8972dd649ff3ecfdd3ed98e0664b5efb432e841408c054c25af26ed3"
         ],
         "linux_mips": [
-          "go1.26.2.linux-mips.tar.gz",
-          "2d57e4167932a4872e31570465f48d8b6818002c77275bae969bdbb6d7238b5e"
+          "go1.26.4.linux-mips.tar.gz",
+          "3435d0d8424562dfcf12517040b6a2388ee0f6f20b9d66b2349a6c5034d57997"
         ],
         "linux_mips64": [
-          "go1.26.2.linux-mips64.tar.gz",
-          "b0b49bb5c528e623a926b8242f03cfd612971150e18eeb3f638d751218c09cdf"
+          "go1.26.4.linux-mips64.tar.gz",
+          "691263ab84943aff78d1422dfae66f352d907fc67560e66e7ceec3898fb7d5e6"
         ],
         "linux_mips64le": [
-          "go1.26.2.linux-mips64le.tar.gz",
-          "5ffc9da2b0ee939c8503c9d9278d6857909ca8577dae3b71221ab2821dc7826a"
+          "go1.26.4.linux-mips64le.tar.gz",
+          "23946b019b118ed85676090fd9110cfa091667c8c52d3d5276b73f3dd46d31f4"
         ],
         "linux_mipsle": [
-          "go1.26.2.linux-mipsle.tar.gz",
-          "ab1fe1c38ffa6bbda029dea33bf36167aca4ff3a25c9d6ed0af38da120678ddc"
+          "go1.26.4.linux-mipsle.tar.gz",
+          "4436df043e2a448f8937d1f944a3cd786d815c872fdce38dd892269845c1c54f"
         ],
         "linux_ppc64": [
-          "go1.26.2.linux-ppc64.tar.gz",
-          "589f7ef241104f153e910244b71d70f4aad0d4584651ca80a5188186dda63a2e"
+          "go1.26.4.linux-ppc64.tar.gz",
+          "d7c3970c1818d63b7b3473a01b9f5f208da1e793a902d3b2e26d5e5174eb6026"
         ],
         "linux_ppc64le": [
-          "go1.26.2.linux-ppc64le.tar.gz",
-          "62b7645dd2404052535617c59e91cf03c7aa28e332dbaddbe4c0d7de7bcc6736"
+          "go1.26.4.linux-ppc64le.tar.gz",
+          "53f49b8c7eace2d30389327b4a516b13321f90377fdf5929a6b63174609bc22e"
         ],
         "linux_riscv64": [
-          "go1.26.2.linux-riscv64.tar.gz",
-          "c5c697faa4dc05364b6e163d2ab8161b32a120eeed54192457d57d7ef7c2091a"
+          "go1.26.4.linux-riscv64.tar.gz",
+          "2b9ba137baaa3031fd74330cb36ab54c5abe380867ca9fbab7c552f3db740555"
         ],
         "linux_s390x": [
-          "go1.26.2.linux-s390x.tar.gz",
-          "410726ed10a0ea6745c2ea8da4f0e769fd3ce819cd4a41a67ad08b094d5dfc31"
+          "go1.26.4.linux-s390x.tar.gz",
+          "1e12a2318f3dd4c57027c865f6cb51f5d1e36b02d10f3e6316ce7b61a27b3ca1"
         ],
         "netbsd_386": [
-          "go1.26.2.netbsd-386.tar.gz",
-          "e8ffab99dd65fef14097d6af48ea6302793f2298a7b2e5f00a284bd933feba4c"
+          "go1.26.4.netbsd-386.tar.gz",
+          "67a172e4780d1b2a5412b73e86798937f2eb2f85aba6d740df4fbe6d6b555fa2"
         ],
         "netbsd_amd64": [
-          "go1.26.2.netbsd-amd64.tar.gz",
-          "1f5c33c923983ee8433ad8098dcd87a0e1fdccd18d05a91844c2be60507a61fe"
+          "go1.26.4.netbsd-amd64.tar.gz",
+          "3321f16e91c7d6d9c8df556690fbe8aef028aac9a0d6d466af9d3c20bd599503"
         ],
         "netbsd_arm": [
-          "go1.26.2.netbsd-arm.tar.gz",
-          "85761320e364b65424d2952a3388970d86e072c8dce8dcad2a1dca41555c2b96"
+          "go1.26.4.netbsd-arm.tar.gz",
+          "a3830f9f0f9fb00648346508d4d2c6fa2d7c1cd4c478fb88051ff6f1b49f0610"
         ],
         "netbsd_arm64": [
-          "go1.26.2.netbsd-arm64.tar.gz",
-          "3ca3561bf4452e799d11e5312182f79cd342d506136cd44c2b47991206ec23f5"
+          "go1.26.4.netbsd-arm64.tar.gz",
+          "f240a98583a12f16cd6ea4799d29e5ccdc96892314263c0065e6511c783e26ab"
         ],
         "openbsd_386": [
-          "go1.26.2.openbsd-386.tar.gz",
-          "0644073c0ae1ade26d26953ef882d7d419855dca25b0e992ae416a47967d37b3"
+          "go1.26.4.openbsd-386.tar.gz",
+          "c0c892180ebc9038637f158a010bdc2d962d303d9c0346ae5856fcd2088b16c7"
         ],
         "openbsd_amd64": [
-          "go1.26.2.openbsd-amd64.tar.gz",
-          "72f69217a88e3d0975a75adf9fc92ff10ea65def56e6c34d8612428bf769581e"
+          "go1.26.4.openbsd-amd64.tar.gz",
+          "cd33f8f7f103cc9151d69795a7f20482335a88cf4eb76a3c56c12afbb5b1b2f0"
         ],
         "openbsd_arm": [
-          "go1.26.2.openbsd-arm.tar.gz",
-          "3aafe792df65abf1777b5cc678075ebba1bd8063e6450e81e742fef696e0bcbd"
+          "go1.26.4.openbsd-arm.tar.gz",
+          "5ab1a54a1dc4f425006101b81c12cd88a457b22496add2bb8b6f6e73b58cf1f1"
         ],
         "openbsd_arm64": [
-          "go1.26.2.openbsd-arm64.tar.gz",
-          "efd410fc60a17690ad43fe8dd00bf1fd4c1dc920d81970b9f422f313b0930b92"
+          "go1.26.4.openbsd-arm64.tar.gz",
+          "cf8b0f5d6a043771df53fe70054d2b2b792f4c7693ad6cd5a891c252d813bc33"
         ],
         "openbsd_ppc64": [
-          "go1.26.2.openbsd-ppc64.tar.gz",
-          "98a2cadd416066739e00b1bc297727c3108dba9001811b177ce57afef518f8bd"
+          "go1.26.4.openbsd-ppc64.tar.gz",
+          "dcf7c6962c43ff67a0d804b989589fe4f3fd574c92b932659c95b1bb32c66f82"
         ],
         "openbsd_riscv64": [
-          "go1.26.2.openbsd-riscv64.tar.gz",
-          "adf39a1a7e56d5c1a2cb69ad06752c5da6b808d2a029b7b6d6d5bb6e11a2168e"
+          "go1.26.4.openbsd-riscv64.tar.gz",
+          "e6ba2daf626770f7d453e7974058dee4b85cb198613ecbb97048a730dc1d5497"
         ],
         "plan9_386": [
-          "go1.26.2.plan9-386.tar.gz",
-          "eb2f95f6f43701eb98a31f5efdd9b5f14ff6e0afd289e1f94559462f83e73cfd"
+          "go1.26.4.plan9-386.tar.gz",
+          "003b912f269786612ad01088178ffcb6f03421fdd61cc4d8b71922571aabd09a"
         ],
         "plan9_amd64": [
-          "go1.26.2.plan9-amd64.tar.gz",
-          "d347fecec7532309fccf3570021ba8a00a0acce120fea02a46cc295936588b0f"
+          "go1.26.4.plan9-amd64.tar.gz",
+          "663871da0f2263d6553828e695be5346f816015f1a6fe7ead22db538ebb6b293"
         ],
         "plan9_arm": [
-          "go1.26.2.plan9-arm.tar.gz",
-          "70700c5af45201a8e82436fb824f3551e357e3002094c8416e78e1aa51d4a0ab"
+          "go1.26.4.plan9-arm.tar.gz",
+          "9b350fc94bb0c17fe30604e41c7573a9a70bbab258646f0e262a4c6851e4d2b8"
         ],
         "solaris_amd64": [
-          "go1.26.2.solaris-amd64.tar.gz",
-          "cd45d13200697b3263e39cdf364f0cb9d9adc39d9574ab575e481b64cb7fb8b1"
+          "go1.26.4.solaris-amd64.tar.gz",
+          "92eb3f7e224e5dd7ac9e0fb9455f8619c3999faf1e350a9505bb2ed5f7e41b7e"
         ],
         "windows_386": [
-          "go1.26.2.windows-386.zip",
-          "4a8b02c34625fecd9c6583442101c9796fc265a5fc1edb9340d71bed0300f94c"
+          "go1.26.4.windows-386.zip",
+          "2064a4a249fd2ee2db23e7080dc19b42768969f2830541841d0f7a9c80996946"
         ],
         "windows_amd64": [
-          "go1.26.2.windows-amd64.zip",
-          "98eb3570bade15cb826b0909338df6cc6d2cf590bc39c471142002db3832b708"
+          "go1.26.4.windows-amd64.zip",
+          "3ca8fb4630b07c419cbdd51f754e31363cfcfb83b3a5354d9e895c90be2cc345"
         ],
         "windows_arm64": [
-          "go1.26.2.windows-arm64.zip",
-          "094d05caaf6ba235e2bd570b625d064ceb65943866252722a8f3fdba232139c6"
+          "go1.26.4.windows-arm64.zip",
+          "62247f56fb7d7b827d237152c4e3fcd69a24d0fa9430dc73dbda7593ae82bc8d"
         ]
       }
     },

--- a/src/zig/uptime_darwin.zig
+++ b/src/zig/uptime_darwin.zig
@@ -1,23 +1,28 @@
 const std = @import("std");
-const c = std.c;
+const posix = std.posix;
 
-const Timeval = extern struct {
-    tv_sec: i64,  // time_t
-    tv_usec: i32, // suseconds_t
-};
+const ctl_kern: c_int = 1;
+const kern_boottime: c_int = 21;
 
 pub fn main() !void {
-    var boottime: c.timeval = undefined;
-    var size: usize = @sizeOf(c.timeval);
+    var boottime: posix.timeval = undefined;
+    var size: usize = @sizeOf(posix.timeval);
+    const mib = [_]c_int{ ctl_kern, kern_boottime };
 
-    if (c.sysctlbyname("kern.boottime", &boottime, &size, null, 0) != 0) {
+    posix.sysctl(&mib, &boottime, &size, null, 0) catch {
         std.log.err("Failed to get system uptime", .{});
         return;
+    };
+
+    var now: posix.timespec = undefined;
+    switch (posix.errno(posix.system.clock_gettime(.REALTIME, &now))) {
+        .SUCCESS => {},
+        else => {
+            std.log.err("Failed to get current time", .{});
+            return;
+        },
     }
 
-    const now = std.time.timestamp();
-    const bt_ptr: *const Timeval = @ptrCast(&boottime);
-
-    const uptime = now - bt_ptr.tv_sec;
+    const uptime = now.sec - boottime.sec;
     std.debug.print("{}\n", .{uptime});
 }


### PR DESCRIPTION
## Summary

- Update the Zig toolchain/runtime pin from 0.15.2 to 0.16.0.
- Refresh `MODULE.bazel.lock` for the updated Zig/rules resolution.
- Update the Darwin Zig uptime implementation for Zig 0.16 by replacing the removed `std.time.timestamp()` helper with Zig `std.posix` APIs for `sysctl` and `clock_gettime`.

## Validation

- `bazel build //src/zig:uptime`
- `bazel-bin/src/zig/uptime`
- `bazel run //tools/format:format.check`
