### PR TITLE
Update Kotlin toolchain to 2.4

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,13 @@
 load("@gazelle//:def.bzl", "gazelle")
+load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
 
 gazelle(name = "gazelle")
+
+define_kt_toolchain(
+    name = "kotlin_2_4_toolchain",
+    api_version = "2.4",
+    language_version = "2.4",
+)
 
 alias(
     name = "format",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,6 +18,9 @@ go_sdk.download(version = "1.26.4")
 
 # kotlin
 bazel_dep(name = "rules_kotlin", version = "2.4.0")
+
+register_toolchains("//:kotlin_2_4_toolchain")
+
 bazel_dep(name = "rules_android", version = "0.7.3")
 bazel_dep(name = "rules_graalvm", version = "0.11.1")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -433,7 +433,7 @@
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "cl5A2O84vDL6Tt+Qga8FCj1DUDGqn+e7ly5rZ+4xvcc=",
-        "usagesDigest": "tiZsmifkpLM+xnn6EXkTF48bYLsbvhr5rcGkv4SuImc=",
+        "usagesDigest": "YrfZ4bJpm8TElVj7Cl9MuPxrvXtxG3i75iLf1pGcdG8=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_tools_telemetry+,bazel_lib bazel_lib+",
           "REPO_MAPPING:aspect_tools_telemetry+,bazel_skylib bazel_skylib+"
@@ -443,7 +443,7 @@
             "repoRuleId": "@@aspect_tools_telemetry+//:extension.bzl%tel_repository",
             "attributes": {
               "deps": {
-                "aspect_rules_lint": "2.7.1",
+                "aspect_rules_lint": "2.7.2",
                 "aspect_tools_telemetry": "0.3.3"
               }
             }


### PR DESCRIPTION
## Summary
- Register a Kotlin 2.4 toolchain in the root BUILD file
- Align Bazel module configuration with `rules_kotlin` 2.4.0
- Refresh the module lockfile to reflect dependency metadata updates

## Testing
- Not run (not requested)