### PR TITLE
[codex] Use rules_swift Linux toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -176,6 +176,29 @@ archive_override(
     urls = ["https://github.com/bazelbuild/rules_swift/releases/download/4.0.0-rc4/rules_swift.4.0.0-rc4.tar.gz"],
 )
 
+swift = use_extension("@build_bazel_rules_swift//swift:extensions.bzl", "swift")
+swift.toolchain(
+    name = "swift_toolchain",
+    platform_sha256 = {
+        # Use the Ubuntu 22.04 toolchain for Linux CI. rules_swift cannot currently
+        # select between Ubuntu releases via platform constraints.
+        "ubuntu22.04": "af1dd256952a928e19ee99d67053f56120c2d20363b96f2017e2038093bfbb49",
+        "ubuntu22.04-aarch64": "cb89091dda0a136a94aaaa4eb122161dd7759bd3fd9bd5c9d890dbc90f213b6c",
+    },
+    swift_version = "6.3",
+)
+use_repo(
+    swift,
+    "swift_toolchain",
+    "swift_toolchain_ubuntu22.04",
+    "swift_toolchain_ubuntu22.04-aarch64",
+)
+
+register_toolchains(
+    "@swift_toolchain//:swift_toolchain_exec_ubuntu22.04",
+    "@swift_toolchain//:swift_toolchain_exec_ubuntu22.04-aarch64",
+)
+
 # zig
 bazel_dep(name = "rules_zig", version = "0.16.0")
 

--- a/renovate.json
+++ b/renovate.json
@@ -61,6 +61,18 @@
                 "/(^|/)MODULE\\.bazel$/"
             ],
             "matchStrings": [
+                "swift\\.toolchain\\([\\s\\S]*?swift_version\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+            ],
+            "datasourceTemplate": "github-releases",
+            "depNameTemplate": "swiftlang/swift",
+            "versioningTemplate": "semver"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/(^|/)MODULE\\.bazel$/"
+            ],
+            "matchStrings": [
                 "url\\s*=\\s*\"https://github\\.com/muttleyxd/clang-tools-static-binaries/releases/download/(?<currentValue>[^\"]+)/clang-format-20_macos-arm-arm64\""
             ],
             "datasourceTemplate": "github-releases",

--- a/script/build.sh
+++ b/script/build.sh
@@ -21,8 +21,8 @@ if [[ "${PLATFORM}" == "linux" ]]; then
 	fi
 fi
 
-# TODO: deps.sh is down here because it needs curl. We could move the curl installation out of install_apt_packages
-#       and rename it to be just the stuff we need for build-essentials, etc.
+# TODO: deps.sh is down here because Linux Bazelisk installation needs curl. We could move
+#       the curl installation out of install_apt_packages.
 # shellcheck source=deps.sh
 source ./script/deps.sh
 

--- a/script/deps.sh
+++ b/script/deps.sh
@@ -4,7 +4,6 @@
 source ./script/common.sh
 
 BAZELISK_VERSION=1.27.0
-SWIFT_VERSION=6.3
 
 function install_bazelisk() {
 	if command -v bazelisk >/dev/null; then
@@ -25,39 +24,6 @@ function install_bazelisk() {
 	echo "Installed Bazelisk to ${bazelisk_path} and added to PATH"
 }
 
-# Can potentially optimize this based on what rules_swift's CI does for Linux:
-# https://github.com/bazelbuild/rules_swift/blob/master/.bazelci/presubmit.yml#L13-L19
-function install_swift_for_linux() {
-	swift_version="${SWIFT_VERSION}"
-	ubuntu_version=$(awk -F= '/^VERSION_ID=/ {gsub(/"/, "", $2); print $2}' /etc/os-release)
-
-	# Because Swift Linux releases put a 'aarch64' in the URL for Arm releases, and nothing at all for x86_64
-	arch="$(uname -m)"
-	if [[ "${arch}" = "arm64" ]] || [[ "${arch}" = "aarch64" ]]; then
-		arch_url_fragment="-aarch64"
-	fi
-
-	if [[ "${arch}" = "x86_64" ]]; then
-		arch_url_fragment=""
-	fi
-
-	install_dir="${HOME}/.cache/swift-${swift_version}-${arch}"
-	if [[ -d "${install_dir}" ]] && [[ -x "${install_dir}/usr/bin/swiftc" ]]; then
-		export PATH="${install_dir}/usr/bin:${PATH}"
-		return
-	fi
-
-	mkdir -p "${install_dir}"
-
-	pushd "${install_dir}" || exit
-	# shellcheck disable=SC2001
-	url="https://download.swift.org/swift-${swift_version}-release/ubuntu$(echo "$ubuntu_version" | sed 's/\.//g')${arch_url_fragment}/swift-${swift_version}-RELEASE/swift-${swift_version}-RELEASE-ubuntu${ubuntu_version}${arch_url_fragment}.tar.gz"
-	curl -sfL "${url}" | tar -xz --strip-components 1 -f -
-	popd || exit
-	# shellcheck disable=SC2155
-	export PATH="${install_dir}/usr/bin:${PATH}"
-}
-
 function report_disk_usage() {
 	curl -sSfL https://raw.githubusercontent.com/bootandy/dust/refs/heads/master/install.sh | sh
 	dust --no-progress /
@@ -75,7 +41,6 @@ if [[ "${PLATFORM}" = "linux" ]]; then
 	fi
 
 	install_bazelisk
-	install_swift_for_linux
 	free_some_disk_space
 	# If there's disk space issues, then uncomment report_disk_usage below to see where space is being eaten up
 	# report_disk_usage

--- a/script/stage.sh
+++ b/script/stage.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # shellcheck source=common.sh
 source ./script/common.sh
 
-# Because we still use bazel in this staging script, we still invoke deps.sh because it will
-# ensure that the PATH is updated to include the swift distribution's bin dirs.
+# Because we still use bazel in this staging script, we still invoke deps.sh so Linux
+# environments have Bazelisk available.
 # shellcheck source=deps.sh
 source ./script/deps.sh
 

--- a/src/swift/patches/swift-static-lib.patch
+++ b/src/swift/patches/swift-static-lib.patch
@@ -71,6 +71,20 @@ index af31dce..e3eb181 100644
 +    linkopts += [
 @@ -519,0 +538 @@ def _swift_toolchain_impl(ctx):
 +            SWIFT_FEATURE_STATIC_STDLIB in ctx.features,
+diff --git a/swift/internal/extensions/BUILD.bazel.tpl b/swift/internal/extensions/BUILD.bazel.tpl
+index 4c78afa..4f147f5 100644
+--- a/swift/internal/extensions/BUILD.bazel.tpl
++++ b/swift/internal/extensions/BUILD.bazel.tpl
+@@ -125,6 +125,7 @@ swift_tools(
+     swift_autolink_extract = "usr/bin/swift-autolink-extract",
+     swift_symbolgraph_extract = "usr/bin/swift-symbolgraph-extract",
+     additional_inputs = glob([
+-        "usr/lib/swift/**"
++        "usr/lib/swift/**",
++        "usr/lib/swift_static/**",
+     ] + [
+         "usr/bin/swift",
+         "usr/bin/swift-frontend",
 diff --git a/tools/worker/work_processor.cc b/tools/worker/work_processor.cc
 index df6021c..9b21c20 100644
 --- a/tools/worker/work_processor.cc


### PR DESCRIPTION
## Summary

- Configure rules_swift's `swift.toolchain` extension to provide the Swift 6.3 Linux toolchain through Bazel.
- Remove the custom shell script logic that downloaded and unpacked Swift from swift.org.
- Add Renovate tracking for the new `swift.toolchain(... swift_version = ...)` location.

## Notes

The rules_swift rc4 toolchain setup still requires choosing a Linux distribution explicitly because Bazel does not have Ubuntu-version platform constraints. This PR registers the Ubuntu 22.04 x86_64 and aarch64 toolchains, matching the current rules_swift guidance and existing CI baseline.

## Validation

- `bazel query @swift_toolchain//:swift_toolchain_exec_ubuntu22.04`
- `bazel build --config=macos //src/swift:uptime`
- `bazel run //tools/format:format.check`

Linux CI is the important final proof that the downloaded Swift archive path works in the target environment.
