### PR TITLE
Automate MODULE.bazel.lock updates for Renovate PRs

### DIFF
--- a/.github/workflows/update-module-lockfile.yml
+++ b/.github/workflows/update-module-lockfile.yml
@@ -1,0 +1,70 @@
+name: Update MODULE.bazel.lock
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - .bazelversion
+      - MODULE.bazel
+      - MODULE.bazel.lock
+      - src/rb/Gemfile
+      - src/rb/Gemfile.lock
+      - src/rs/Cargo.lock
+      - src/rs/Cargo.toml
+      - tools/patches/**
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  update-lockfile:
+    if: >
+      github.event.pull_request.user.login == 'renovate[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Get Bazel repository cache path
+        id: get-cache-path
+        run: |
+          echo "bazel_repo_cache_path=$(bazel info repository_cache)" >>"$GITHUB_OUTPUT"
+
+      - name: Restore repo cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ steps.get-cache-path.outputs.bazel_repo_cache_path }}
+          key: ubuntu-24.04
+
+      - name: Update lockfile
+        run: bazel mod deps --lockfile_mode=update --extension_info=all
+
+      - name: Commit lockfile update
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          git add MODULE.bazel.lock
+          if git diff --cached --quiet; then
+            echo "MODULE.bazel.lock is already current."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Update MODULE.bazel.lock"
+
+          git fetch "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$HEAD_REF"
+          git rebase FETCH_HEAD
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${HEAD_REF}"

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -366,7 +366,7 @@
   "moduleExtensions": {
     "@@aspect_rules_js+//npm:extensions.bzl%pnpm": {
       "general": {
-        "bzlTransitiveDigest": "NoKJK2nhdY2qPq1PrRxfbpdE/MIt3808NO2QI7vdBt4=",
+        "bzlTransitiveDigest": "KBb9K2l7vCJX9nKahu9f8pujkpbxLYwoaoJUTm5eHPU=",
         "usagesDigest": "ZYGEy1FrDUNPBzAzD+ujlHkMEsVPMYOvpHm9RhUexUE=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_bazel_lib+,bazel_lib bazel_lib+",
@@ -433,7 +433,7 @@
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "cl5A2O84vDL6Tt+Qga8FCj1DUDGqn+e7ly5rZ+4xvcc=",
-        "usagesDigest": "tiZsmifkpLM+xnn6EXkTF48bYLsbvhr5rcGkv4SuImc=",
+        "usagesDigest": "YrfZ4bJpm8TElVj7Cl9MuPxrvXtxG3i75iLf1pGcdG8=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_tools_telemetry+,bazel_lib bazel_lib+",
           "REPO_MAPPING:aspect_tools_telemetry+,bazel_skylib bazel_skylib+"
@@ -443,7 +443,7 @@
             "repoRuleId": "@@aspect_tools_telemetry+//:extension.bzl%tel_repository",
             "attributes": {
               "deps": {
-                "aspect_rules_lint": "2.7.1",
+                "aspect_rules_lint": "2.7.2",
                 "aspect_tools_telemetry": "0.3.3"
               }
             }
@@ -890,7 +890,7 @@
     },
     "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
       "general": {
-        "bzlTransitiveDigest": "0UoEjDQrkPOE9U+EQx4lrz7qpp6evMn/oeanXvUNkJs=",
+        "bzlTransitiveDigest": "woydGULL0atBo9HxY+e+xLkH/IYTzUJw/wocm1G6jDA=",
         "usagesDigest": "ZmL90WEq2B6/NJ8rtHAqdnDPn+/9xG/GWR5K4UU4tyo=",
         "recordedInputs": [
           "REPO_MAPPING:bazel_features+,bazel_features_globals bazel_features++version_extension+bazel_features_globals",


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that updates `MODULE.bazel.lock` on Renovate PRs when Bazel inputs change
- Commit and push the regenerated lockfile back to the PR branch
- Refresh `MODULE.bazel.lock` for updated dependency digests and `aspect_rules_lint` 2.7.2

## Testing
- Not run (not requested)