### PR TITLE
Remove dotnet libs to free up space on Linux

### DIFF
--- a/script/deps.sh
+++ b/script/deps.sh
@@ -58,6 +58,11 @@ function install_swift_for_linux() {
 	export PATH="${install_dir}/usr/bin:${PATH}"
 }
 
+function install_dust() {
+    curl -sSfL https://raw.githubusercontent.com/bootandy/dust/refs/heads/master/install.sh | sh
+}
+
+
 if [[ "${PLATFORM}" = "linux" ]]; then
 	if [[ "$(awk -F= '/^ID=/ {gsub(/"/, "", $2); print $2}' /etc/os-release)" != "ubuntu" ]]; then
 		echo "On Linux, only Ubuntu platform is supported for building (for now)" >&2
@@ -66,6 +71,8 @@ if [[ "${PLATFORM}" = "linux" ]]; then
 
 	install_bazelisk
 	install_swift_for_linux
+	install_dust
+	dust
 fi
 
 if [[ "${PLATFORM}" == "macos" ]]; then

--- a/script/deps.sh
+++ b/script/deps.sh
@@ -59,9 +59,8 @@ function install_swift_for_linux() {
 }
 
 function install_dust() {
-    curl -sSfL https://raw.githubusercontent.com/bootandy/dust/refs/heads/master/install.sh | sh
+	curl -sSfL https://raw.githubusercontent.com/bootandy/dust/refs/heads/master/install.sh | sh
 }
-
 
 if [[ "${PLATFORM}" = "linux" ]]; then
 	if [[ "$(awk -F= '/^ID=/ {gsub(/"/, "", $2); print $2}' /etc/os-release)" != "ubuntu" ]]; then
@@ -72,7 +71,7 @@ if [[ "${PLATFORM}" = "linux" ]]; then
 	install_bazelisk
 	install_swift_for_linux
 	install_dust
-	dust
+	dust /
 fi
 
 if [[ "${PLATFORM}" == "macos" ]]; then

--- a/script/deps.sh
+++ b/script/deps.sh
@@ -64,11 +64,8 @@ function report_disk_usage() {
 }
 
 function free_some_disk_space() {
-	set -x
-	rm -rf /usr/local/lib/android/sdk/ndk
 	sudo rm -rf /usr/share/dotnet
-	set +x
-	# Other potential candidates could be /usr/share/dotnet/...
+	# Other potential candidates could be /usr/local/lib/android/sdk/...
 }
 
 if [[ "${PLATFORM}" = "linux" ]]; then

--- a/script/deps.sh
+++ b/script/deps.sh
@@ -64,7 +64,10 @@ function report_disk_usage() {
 }
 
 function free_some_disk_space() {
+	set -x
 	rm -rf /usr/local/lib/android/sdk/ndk
+	sudo rm -rf /usr/share/dotnet
+	set +x
 	# Other potential candidates could be /usr/share/dotnet/...
 }
 

--- a/script/deps.sh
+++ b/script/deps.sh
@@ -58,8 +58,14 @@ function install_swift_for_linux() {
 	export PATH="${install_dir}/usr/bin:${PATH}"
 }
 
-function install_dust() {
+function report_disk_usage() {
 	curl -sSfL https://raw.githubusercontent.com/bootandy/dust/refs/heads/master/install.sh | sh
+	dust --no-progress /
+}
+
+function free_some_disk_space() {
+	rm -rf /usr/local/lib/android/sdk/ndk
+	# Other potential candidates could be /usr/share/dotnet/...
 }
 
 if [[ "${PLATFORM}" = "linux" ]]; then
@@ -70,8 +76,9 @@ if [[ "${PLATFORM}" = "linux" ]]; then
 
 	install_bazelisk
 	install_swift_for_linux
-	install_dust
-	dust /
+	free_some_disk_space
+	# If there's disk space issues, then uncomment report_disk_usage below to see where space is being eaten up
+	# report_disk_usage
 fi
 
 if [[ "${PLATFORM}" == "macos" ]]; then


### PR DESCRIPTION
Was starting to run out of disk on some Linux runners, delete dotnet and make it easier to audit disk usage in the future.